### PR TITLE
Fix Vercel function runtime configuration error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,10 +29,5 @@
         }
       ]
     }
-  ],
-  "functions": {
-    "api/**/*.js": {
-      "runtime": "nodejs18.x"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Problem
The build was failing with the error:
```
Function Runtimes must have a valid version, for example `now-php@1.0.0`.
```

This was caused by an invalid runtime specification in the `vercel.json` file.

## Solution
- Removed the incorrect `functions` configuration block that specified `"runtime": "nodejs18.x"`
- Modern Vercel automatically detects and handles Node.js API routes without explicit runtime configuration
- The existing API functions (`api/version.js` and `api/security/health-check.js`) use ES modules (`export default`) which are fully compatible with Vercel's auto-detection

## Changes
- **vercel.json**: Removed the `functions` configuration block with invalid runtime specification
- No changes to API functionality - they will continue to work as expected

## Testing
- ✅ Verified `vercel.json` syntax is valid JSON
- ✅ Confirmed API functions use proper ES module format
- ✅ Build configuration remains intact

## Impact
- Fixes deployment build errors
- No breaking changes to existing functionality
- API endpoints will continue to work as before

The deployment should now succeed without the runtime configuration error.