### PR TITLE
Add Trending Cards as a Separate Tab in Card Explorer

### DIFF
--- a/src/components/CardMetaAnalysis.jsx
+++ b/src/components/CardMetaAnalysis.jsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { TrendingUp, TrendingDown, Eye, Download } from 'lucide-react';
+import {
+  TrendingUp,
+  TrendingDown,
+  Eye,
+  Download,
+  Filter,
+  ArrowRight,
+  BarChart2,
+  PieChart,
+} from 'lucide-react';
 import { motion } from 'framer-motion';
 
 const CardMetaAnalysis = () => {
@@ -53,58 +62,142 @@ const CardMetaAnalysis = () => {
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
-      className="bg-card rounded-lg p-6 mb-6"
+      className="space-y-6"
     >
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-bold">Trending Cards</h3>
-        <button className="flex items-center gap-1 px-2 py-1 text-xs text-secondary hover:text-primary transition-colors">
-          <Download size={12} />
-          Export
-        </button>
+      {/* Filters and Controls */}
+      <div className="bg-card rounded-lg p-4 border border-color">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-bold flex items-center gap-2">
+              <TrendingUp className="w-5 h-5 text-primary" />
+              Trending Cards Analysis
+            </h3>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="relative">
+              <select className="pl-3 pr-8 py-2 bg-background border border-color rounded-lg text-sm appearance-none focus:outline-none focus:ring-2 focus:ring-primary">
+                <option>Last 7 days</option>
+                <option>Last 30 days</option>
+                <option>Last 3 months</option>
+                <option>All time</option>
+              </select>
+              <Filter className="absolute right-2 top-1/2 transform -translate-y-1/2 w-4 h-4 text-secondary pointer-events-none" />
+            </div>
+            <button className="flex items-center gap-1 px-3 py-2 bg-primary text-white rounded-lg text-sm">
+              <Download className="w-4 h-4" />
+              Export Data
+            </button>
+          </div>
+        </div>
       </div>
 
+      {/* Stats Overview */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {trendingCards.map((card, index) => (
-          <div key={index} className="border border-color rounded-lg p-3">
-            <div className="flex items-center justify-between mb-2">
-              <h4 className="font-semibold text-sm">{card.name}</h4>
-              <div className="flex items-center gap-1 text-xs">
-                {card.trend === 'up' ? (
-                  <div className="flex items-center gap-1 text-green-500">
-                    <TrendingUp size={14} />
-                    <span>+{card.trendValue}%</span>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-1 text-red-500">
-                    <TrendingDown size={14} />
-                    <span>-{card.trendValue}%</span>
-                  </div>
-                )}
-              </div>
+        <div className="bg-card rounded-lg p-4 border border-color">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="p-2 bg-blue-100 text-blue-600 rounded-lg">
+              <Eye className="w-5 h-5" />
             </div>
-            <p className="text-xs text-secondary mb-2">
-              Played in {card.playRate}% of {card.color} decks
-            </p>
-            <div className="w-full bg-tertiary rounded-full h-2">
-              <div
-                className={`bg-gradient-to-r ${
-                  card.color === 'yellow'
-                    ? 'from-yellow-500 to-yellow-600'
-                    : card.color === 'red'
-                      ? 'from-red-500 to-red-600'
-                      : card.color === 'green'
-                        ? 'from-green-500 to-green-600'
-                        : card.color === 'blue'
-                          ? 'from-blue-500 to-blue-600'
-                          : card.color === 'purple'
-                            ? 'from-purple-500 to-purple-600'
-                            : 'from-yellow-500 to-yellow-600'
-                } h-2 rounded-full`}
-                style={{ width: `${card.playRate}%` }}
-              ></div>
+            <div>
+              <div className="text-sm text-secondary">Most Viewed</div>
+              <div className="font-bold">Lightning Strike</div>
             </div>
           </div>
-        ))}
+          <div className="text-xs text-secondary">
+            Viewed 2,345 times in the last 7 days
+          </div>
+        </div>
+        <div className="bg-card rounded-lg p-4 border border-color">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="p-2 bg-green-100 text-green-600 rounded-lg">
+              <TrendingUp className="w-5 h-5" />
+            </div>
+            <div>
+              <div className="text-sm text-secondary">Biggest Gainer</div>
+              <div className="font-bold">Shadow Veil</div>
+            </div>
+          </div>
+          <div className="text-xs text-secondary">
+            Usage increased by 23% in the last 7 days
+          </div>
+        </div>
+        <div className="bg-card rounded-lg p-4 border border-color">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="p-2 bg-red-100 text-red-600 rounded-lg">
+              <TrendingDown className="w-5 h-5" />
+            </div>
+            <div>
+              <div className="text-sm text-secondary">Biggest Decliner</div>
+              <div className="font-bold">Crystal Shield</div>
+            </div>
+          </div>
+          <div className="text-xs text-secondary">
+            Usage decreased by 12% in the last 7 days
+          </div>
+        </div>
+      </div>
+
+      {/* Trending Cards Grid */}
+      <div className="bg-card rounded-lg p-6 border border-color">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-bold">Top Trending Cards</h3>
+          <div className="flex items-center gap-2">
+            <button className="p-2 bg-background rounded-lg text-secondary hover:text-primary transition-colors">
+              <BarChart2 className="w-4 h-4" />
+            </button>
+            <button className="p-2 bg-background rounded-lg text-secondary hover:text-primary transition-colors">
+              <PieChart className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {trendingCards.map((card, index) => (
+            <div key={index} className="border border-color rounded-lg p-4 hover:shadow-md transition-shadow">
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="font-semibold">{card.name}</h4>
+                <div className="flex items-center gap-1 text-xs">
+                  {card.trend === 'up' ? (
+                    <div className="flex items-center gap-1 text-green-500">
+                      <TrendingUp size={14} />
+                      <span>+{card.trendValue}%</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1 text-red-500">
+                      <TrendingDown size={14} />
+                      <span>-{card.trendValue}%</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <p className="text-sm text-secondary mb-3">
+                Played in {card.playRate}% of {card.color} decks
+              </p>
+              <div className="w-full bg-tertiary rounded-full h-2 mb-2">
+                <div
+                  className={`bg-gradient-to-r ${
+                    card.color === 'yellow'
+                      ? 'from-yellow-500 to-yellow-600'
+                      : card.color === 'red'
+                      ? 'from-red-500 to-red-600'
+                      : card.color === 'green'
+                      ? 'from-green-500 to-green-600'
+                      : card.color === 'blue'
+                      ? 'from-blue-500 to-blue-600'
+                      : card.color === 'purple'
+                      ? 'from-purple-500 to-purple-600'
+                      : 'from-yellow-500 to-yellow-600'
+                  } h-2 rounded-full`}
+                  style={{ width: `${card.playRate}%` }}
+                ></div>
+              </div>
+              <button className="w-full flex items-center justify-center gap-1 mt-2 text-xs text-primary hover:text-primary-dark transition-colors">
+                View card details
+                <ArrowRight size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
       </div>
     </motion.div>
   );

--- a/src/components/CardMetaAnalysis.jsx
+++ b/src/components/CardMetaAnalysis.jsx
@@ -153,7 +153,10 @@ const CardMetaAnalysis = () => {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {trendingCards.map((card, index) => (
-            <div key={index} className="border border-color rounded-lg p-4 hover:shadow-md transition-shadow">
+            <div
+              key={index}
+              className="border border-color rounded-lg p-4 hover:shadow-md transition-shadow"
+            >
               <div className="flex items-center justify-between mb-3">
                 <h4 className="font-semibold">{card.name}</h4>
                 <div className="flex items-center gap-1 text-xs">
@@ -179,14 +182,14 @@ const CardMetaAnalysis = () => {
                     card.color === 'yellow'
                       ? 'from-yellow-500 to-yellow-600'
                       : card.color === 'red'
-                      ? 'from-red-500 to-red-600'
-                      : card.color === 'green'
-                      ? 'from-green-500 to-green-600'
-                      : card.color === 'blue'
-                      ? 'from-blue-500 to-blue-600'
-                      : card.color === 'purple'
-                      ? 'from-purple-500 to-purple-600'
-                      : 'from-yellow-500 to-yellow-600'
+                        ? 'from-red-500 to-red-600'
+                        : card.color === 'green'
+                          ? 'from-green-500 to-green-600'
+                          : card.color === 'blue'
+                            ? 'from-blue-500 to-blue-600'
+                            : card.color === 'purple'
+                              ? 'from-purple-500 to-purple-600'
+                              : 'from-yellow-500 to-yellow-600'
                   } h-2 rounded-full`}
                   style={{ width: `${card.playRate}%` }}
                 ></div>

--- a/src/pages/CardExplorer.jsx
+++ b/src/pages/CardExplorer.jsx
@@ -1,6 +1,14 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Search, Filter, Bot, ChevronRight, ChevronLeft, Grid, TrendingUp } from 'lucide-react';
+import {
+  Search,
+  Filter,
+  Bot,
+  ChevronRight,
+  ChevronLeft,
+  Grid,
+  TrendingUp,
+} from 'lucide-react';
 import CardDatabase from '../components/CardDatabase';
 import AdvancedSearch from '../components/AdvancedSearch';
 import AIAssistant from '../components/AIAssistant';
@@ -127,7 +135,7 @@ const CardExplorer = () => {
                 Trending Cards
               </button>
             </div>
-            
+
             {/* Tab Content */}
             {activeTab === 'all' ? (
               /* Card Database */

--- a/src/pages/CardExplorer.jsx
+++ b/src/pages/CardExplorer.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Search, Filter, Bot, ChevronRight, ChevronLeft } from 'lucide-react';
+import { Search, Filter, Bot, ChevronRight, ChevronLeft, Grid, TrendingUp } from 'lucide-react';
 import CardDatabase from '../components/CardDatabase';
 import AdvancedSearch from '../components/AdvancedSearch';
 import AIAssistant from '../components/AIAssistant';
@@ -11,6 +11,7 @@ const CardExplorer = () => {
   const [searchResults, setSearchResults] = useState(null);
   const [activeSearchCriteria, setActiveSearchCriteria] = useState(null);
   const [showAIAssistant, setShowAIAssistant] = useState(false);
+  const [activeTab, setActiveTab] = useState('all'); // 'all' or 'trending'
 
   const handleAdvancedSearch = criteria => {
     setActiveSearchCriteria(criteria);
@@ -101,15 +102,44 @@ const CardExplorer = () => {
               )}
             </div>
 
-            {/* Card Meta Analysis - Added from Analytics Hub */}
-            <CardMetaAnalysis />
-
-            {/* Card Database */}
-            <CardDatabase
-              cards={searchResults}
-              searchCriteria={activeSearchCriteria}
-              showSearchInterface={true}
-            />
+            {/* Tabs */}
+            <div className="flex border-b border-color mb-6">
+              <button
+                onClick={() => setActiveTab('all')}
+                className={`flex items-center gap-2 px-4 py-3 font-medium transition-colors ${
+                  activeTab === 'all'
+                    ? 'text-primary border-b-2 border-primary'
+                    : 'text-secondary hover:text-primary'
+                }`}
+              >
+                <Grid className="w-4 h-4" />
+                All Cards
+              </button>
+              <button
+                onClick={() => setActiveTab('trending')}
+                className={`flex items-center gap-2 px-4 py-3 font-medium transition-colors ${
+                  activeTab === 'trending'
+                    ? 'text-primary border-b-2 border-primary'
+                    : 'text-secondary hover:text-primary'
+                }`}
+              >
+                <TrendingUp className="w-4 h-4" />
+                Trending Cards
+              </button>
+            </div>
+            
+            {/* Tab Content */}
+            {activeTab === 'all' ? (
+              /* Card Database */
+              <CardDatabase
+                cards={searchResults}
+                searchCriteria={activeSearchCriteria}
+                showSearchInterface={true}
+              />
+            ) : (
+              /* Trending Cards */
+              <CardMetaAnalysis />
+            )}
           </motion.div>
 
           {/* AI Assistant Panel */}


### PR DESCRIPTION
## Changes Made

This PR adds a tabbed interface to the Card Explorer page, separating the card database and trending cards into separate tabs.

### Features Added:

1. Added a tabbed interface with "All Cards" and "Trending Cards" tabs
2. Enhanced the CardMetaAnalysis component with more detailed trending card information
3. Added statistics overview section to the trending cards tab
4. Improved the visual design of the trending cards display

### Technical Details:

- Modified `src/pages/CardExplorer.jsx` to add tab navigation
- Enhanced `src/components/CardMetaAnalysis.jsx` with additional UI elements and statistics
- Added state management for active tab selection

### Screenshots:

The Card Explorer page now has two tabs:
- "All Cards" tab shows the card database with search functionality
- "Trending Cards" tab shows trending card statistics and analysis

### Testing:

The changes have been tested locally and all components render correctly. The tab navigation works as expected, and the trending cards display properly in their dedicated tab.

@MichaelWBrennan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/adf174ccb82d46f88b0a5d06e0b3b7fc)