### PR TITLE
fix: Add missing Eye import for content display

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import {
   Filter,
   Calendar,
   Star,
+  Eye,
   Download,
   ExternalLink,
   Clock,


### PR DESCRIPTION
🔧 IMPORT FIX: Restored Eye icon for view counts

🐛 Bug Fix:
- Added back Eye import that was accidentally removed
- Eye icon is used in content cards to display view counts
- Fixed ReferenceError: Eye is not defined

✅ Functionality Restored:
- View count icons now display properly in content cards
- All content sections working correctly
- No console errors or missing references

🧪 Testing:
- Build successful without errors
- Dev server running without issues
- All pages loading and functioning properly
- Rules page dropdown sections working correctly

This fix ensures all content display features work properly while maintaining the clean interface improvements.