### PR TITLE
Fix card art display in MobileCardExplorer and update mapping utility

### DIFF
--- a/src/pages/MobileCardExplorer.jsx
+++ b/src/pages/MobileCardExplorer.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useData } from '../contexts/DataContext';
+import { getCardArtPathFromData } from '../utils/cardArtMapping';
 
 const MobileCardExplorer = () => {
   const { cards, loading, error } = useData();
@@ -131,7 +132,7 @@ const MobileCardExplorer = () => {
             className="mobile-game-card mobile-mb"
           >
             <img 
-              src={card.imageUrl} 
+              src={getCardArtPathFromData(card) || '/assets/card-back.jpg'} 
               alt={card.name} 
               className="mobile-game-card-img"
               onError={(e) => {


### PR DESCRIPTION
- Updated getAllCardArtsWithData() to use ASCII filenames (PH, TH, G, S)
- Fixed MobileCardExplorer to use getCardArtPathFromData() instead of non-existent imageUrl
- Cards page should now display actual card art instead of fallback images
- Resolves production issue where /cards route showed no images