### PR TITLE
Update card images to link to card information in Scryfall-like format

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,6 +125,10 @@ function App() {
                               element={<CardPage />}
                             />
                             <Route
+                              path="/card/:set/:cardId/:cardName"
+                              element={<CardPage />}
+                            />
+                            <Route
                               path="/card-art-showcase"
                               element={<CardArtShowcase />}
                             />

--- a/src/components/cards/CardArtDisplay.jsx
+++ b/src/components/cards/CardArtDisplay.jsx
@@ -18,6 +18,7 @@ import {
   getCardImagePath,
   getFallbackImagePaths,
 } from '../../utils/imageLoader';
+import CardInfoLink from './CardInfoLink';
 
 /**
  * CardArtDisplay - Component to display KONIVRER card arts
@@ -186,12 +187,12 @@ const CardArtDisplay = ({
     </motion.div>
   );
 
-  // Wrap with Link if clickable and has data
+  // Wrap with CardInfoLink if clickable and has data
   if (clickable && hasData && detailUrl) {
     return (
-      <Link to={detailUrl} className="block">
+      <CardInfoLink cardName={cardName}>
         {cardContent}
-      </Link>
+      </CardInfoLink>
     );
   }
 
@@ -291,28 +292,38 @@ export const CardArtGallery = ({
             transition={{ duration: 0.3, delay: index * 0.1 }}
             className="group"
           >
-            <CardArtDisplay
-              cardName={cardName}
-              className="aspect-card group-hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
-              showCardInfo={showCardInfo}
-              clickable={clickable}
-            />
-            <div className="mt-2 text-center">
-              <div
-                className={`text-sm transition-colors ${
-                  hasData && clickable
-                    ? 'text-gray-300 group-hover:text-white'
-                    : 'text-gray-400'
-                }`}
-              >
-                {displayName}
-              </div>
-              {hasData && (
-                <div className="text-xs text-green-400 opacity-0 group-hover:opacity-100 transition-opacity">
-                  Click to view details
+            {hasData && clickable ? (
+              <CardInfoLink cardName={cardName}>
+                <CardArtDisplay
+                  cardName={cardName}
+                  className="aspect-card group-hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
+                  showCardInfo={showCardInfo}
+                  clickable={false}
+                />
+                <div className="mt-2 text-center">
+                  <div className="text-sm transition-colors text-gray-300 group-hover:text-white">
+                    {displayName}
+                  </div>
+                  <div className="text-xs text-green-400 opacity-0 group-hover:opacity-100 transition-opacity">
+                    Click to view details
+                  </div>
                 </div>
-              )}
-            </div>
+              </CardInfoLink>
+            ) : (
+              <>
+                <CardArtDisplay
+                  cardName={cardName}
+                  className="aspect-card group-hover:scale-105 transition-transform duration-300 shadow-lg hover:shadow-xl"
+                  showCardInfo={showCardInfo}
+                  clickable={clickable}
+                />
+                <div className="mt-2 text-center">
+                  <div className="text-sm transition-colors text-gray-400">
+                    {displayName}
+                  </div>
+                </div>
+              </>
+            )}
           </motion.div>
         );
       })}
@@ -334,12 +345,23 @@ export const CardArtPreview = ({
 
   return (
     <div className="bg-black/30 backdrop-blur-sm rounded-xl p-6 max-w-md mx-auto">
-      <CardArtDisplay
-        cardName={cardName}
-        className="aspect-card mb-4 shadow-2xl"
-        clickable={clickable}
-        showCardInfo={false}
-      />
+      {hasData && clickable ? (
+        <CardInfoLink cardName={cardName}>
+          <CardArtDisplay
+            cardName={cardName}
+            className="aspect-card mb-4 shadow-2xl"
+            clickable={false}
+            showCardInfo={false}
+          />
+        </CardInfoLink>
+      ) : (
+        <CardArtDisplay
+          cardName={cardName}
+          className="aspect-card mb-4 shadow-2xl"
+          clickable={false}
+          showCardInfo={false}
+        />
+      )}
 
       {showDetails && (
         <div className="text-center">

--- a/src/components/cards/CardInfoLink.jsx
+++ b/src/components/cards/CardInfoLink.jsx
@@ -1,0 +1,51 @@
+/**
+ * KONIVRER Deck Database
+ *
+ * Copyright (c) 2024 KONIVRER Deck Database
+ * Licensed under the MIT License
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ExternalLink } from 'lucide-react';
+import { getCardIdFromArtName, getCardDisplayName } from '../../utils/cardArtMapping';
+
+/**
+ * CardInfoLink - Component to wrap card images with links to their information
+ * in a format similar to Scryfall links
+ */
+const CardInfoLink = ({ cardName, children, className = '' }) => {
+  const cardId = getCardIdFromArtName(cardName);
+  const displayName = getCardDisplayName(cardName);
+  
+  // If no card data is available, just render the children without a link
+  if (!cardId) {
+    return <>{children}</>;
+  }
+  
+  // Format the URL similar to Scryfall: /card/set/id/name
+  // For KONIVRER, we'll use: /card/konivrer/id/name
+  const formattedName = displayName.toLowerCase().replace(/[^a-z0-9]/g, '-');
+  // Remove any trailing dashes
+  const cleanFormattedName = formattedName.replace(/-+$/, '');
+  const infoUrl = `/card/konivrer/${cardId}/${cleanFormattedName}`;
+  
+  return (
+    <div className={`group relative ${className}`}>
+      <Link to={infoUrl} className="block">
+        {children}
+        <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center">
+          <ExternalLink className="w-6 h-6 text-white mb-2" />
+          <div className="text-white text-sm font-medium text-center px-2">
+            {displayName}
+          </div>
+          <div className="text-gray-300 text-xs mt-1">
+            View Card Details
+          </div>
+        </div>
+      </Link>
+    </div>
+  );
+};
+
+export default CardInfoLink;

--- a/src/pages/CardPage.jsx
+++ b/src/pages/CardPage.jsx
@@ -50,15 +50,16 @@ import {
 import CardArtDisplay from '../components/cards/CardArtDisplay';
 
 const CardPage = () => {
-  const { id } = useParams();
+  const { id, cardId, set } = useParams();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('details');
   const [isFavorite, setIsFavorite] = useState(false);
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [quantity, setQuantity] = useState(1);
 
-  // Find card by ID
-  const card = cardsData.find(c => c.id === parseInt(id));
+  // Find card by ID - support both URL formats
+  const effectiveId = cardId || id;
+  const card = cardsData.find(c => c.id === effectiveId || c.id === parseInt(effectiveId));
 
   if (!card) {
     return (


### PR DESCRIPTION
## Description
This PR updates all card images to be links to their information in a format identical to Scryfall links (e.g., https://scryfall.com/card/dmc/91/unite-the-coalition).

## Changes
- Added a new `CardInfoLink` component that wraps card images with links to their information
- Updated the `CardArtDisplay` component to use the new `CardInfoLink` component
- Updated the `CardArtGallery` component to use the new `CardInfoLink` component
- Updated the `CardArtPreview` component to use the new `CardInfoLink` component
- Added a new route to handle the Scryfall-like URL format: `/card/:set/:cardId/:cardName`
- Updated the `CardPage` component to handle both the old and new URL formats

## Technical Details
- The new URL format is: `/card/konivrer/:cardId/:cardName`
- Card names are formatted to be URL-friendly (lowercase, spaces replaced with dashes, special characters removed)
- When hovering over a card image, an overlay appears showing the card name and a "View Card Details" message
- The card page can now be accessed via both the old URL format (`/card/:cardId`) and the new Scryfall-like format

## Benefits
- Improves the user experience by making card images clickable links to their information
- Makes the URL format more user-friendly and consistent with industry standards
- Provides a more intuitive way to navigate between cards and their details
- Enhances the overall card browsing experience

## Testing
- Verified that all card images are now clickable links to their information
- Confirmed that the new URL format works correctly
- Tested the hover overlay functionality
- Ensured that the card page displays correctly when accessed via both URL formats

@MichaelWBrennan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/723539de04dd475587bb17e9c8ae3c3c)