### PR TITLE
Update KONIVRER elements to use correct names: Aether, Nether, Fire, …

### DIFF
--- a/src/components/cards/EnhancedCardSearch.jsx
+++ b/src/components/cards/EnhancedCardSearch.jsx
@@ -658,13 +658,12 @@ const EnhancedCardSearch = () => {
 // Advanced Search Panel Component
 const AdvancedSearchPanel = ({ search, onSearchChange }) => {
   const colors = [
-    'Quintessence',
-    'Brilliance', 
-    'Gust',
-    'Inferno',
-    'Steadfast',
-    'Submerged',
-    'Void'
+    'aether',
+    'air',
+    'fire',
+    'earth',
+    'water',
+    'nether'
   ];
   const rarities = ['common', 'uncommon', 'rare', 'mythic'];
   const types = [

--- a/src/engine/elementalAbilities.js
+++ b/src/engine/elementalAbilities.js
@@ -99,6 +99,16 @@ export function getAbilityDisplayInfo(ability) {
   };
 }
 
+// All elements for UI components (using proper element names)
+export const ALL_ELEMENTS = [
+  'aether',
+  'air', 
+  'fire',
+  'earth',
+  'water',
+  'nether'
+];
+
 /**
  * Parse card elements and return display-friendly format
  * @param {Array} elements - Array of element/ability names from card

--- a/src/pages/AdvancedSearchPage.jsx
+++ b/src/pages/AdvancedSearchPage.jsx
@@ -19,13 +19,12 @@ const AdvancedSearchPage = () => {
 
   const elements = [
     { value: '', label: 'Any Element' },
-    { value: 'Quintessence', label: 'Quintessence' },
-    { value: 'Brilliance', label: 'Brilliance (Aether)' },
-    { value: 'Gust', label: 'Gust (Air)' },
-    { value: 'Inferno', label: 'Inferno (Fire)' },
-    { value: 'Steadfast', label: 'Steadfast (Earth)' },
-    { value: 'Submerged', label: 'Submerged (Water)' },
-    { value: 'Void', label: 'Void (Nether)' },
+    { value: 'aether', label: 'Aether' },
+    { value: 'air', label: 'Air' },
+    { value: 'fire', label: 'Fire' },
+    { value: 'earth', label: 'Earth' },
+    { value: 'water', label: 'Water' },
+    { value: 'nether', label: 'Nether' },
   ];
 
   const rarities = [

--- a/src/pages/SyntaxGuide.jsx
+++ b/src/pages/SyntaxGuide.jsx
@@ -93,33 +93,30 @@ const SyntaxGuide = () => {
       description: 'Search by KONIVRER elements',
       examples: [
         {
-          syntax: 'e:brilliance',
-          description: 'Find cards with Brilliance element',
+          syntax: 'e:aether',
+          description: 'Find cards with Aether element',
         },
         {
-          syntax: 'e:gust',
-          description: 'Find cards with Gust element',
+          syntax: 'e:nether',
+          description: 'Find cards with Nether element',
         },
         {
-          syntax: 'e:inferno',
-          description: 'Find cards with Inferno element',
+          syntax: 'e:fire',
+          description: 'Find cards with Fire element',
         },
         {
-          syntax: 'e:steadfast',
-          description: 'Find cards with Steadfast element',
+          syntax: 'e:water',
+          description: 'Find cards with Water element',
         },
         {
-          syntax: 'e:submerged',
-          description: 'Find cards with Submerged element',
+          syntax: 'e:earth',
+          description: 'Find cards with Earth element',
         },
         {
-          syntax: 'e:void',
-          description: 'Find cards with Void element',
+          syntax: 'e:air',
+          description: 'Find cards with Air element',
         },
-        {
-          syntax: 'e:quintessence',
-          description: 'Find cards with Quintessence element',
-        },
+
         {
           syntax: 'e>=2',
           description: 'Find cards with 2 or more elements',
@@ -133,15 +130,15 @@ const SyntaxGuide = () => {
       description: 'Search by card keywords and abilities',
       examples: [
         {
-          syntax: 'k:brilliance',
-          description: 'Find cards with Brilliance keyword',
+          syntax: 'k:aether',
+          description: 'Find cards with Aether keyword',
         },
         {
-          syntax: 'k:void',
-          description: 'Find cards with Void keyword',
+          syntax: 'k:nether',
+          description: 'Find cards with Nether keyword',
         },
         {
-          syntax: 'keyword:steadfast',
+          syntax: 'keyword:earth',
           description: 'Alternative syntax for keyword searches',
         },
       ],
@@ -201,24 +198,24 @@ const SyntaxGuide = () => {
       description: 'Complex search combinations and operators',
       examples: [
         {
-          syntax: 't:elemental e:brilliance',
-          description: 'Find Brilliance Elemental cards',
+          syntax: 't:elemental e:aether',
+          description: 'Find Aether Elemental cards',
         },
         {
-          syntax: 'e:gust e:inferno c<=3',
-          description: 'Find low-cost Gust/Inferno cards',
+          syntax: 'e:air e:fire c<=3',
+          description: 'Find low-cost Air/Fire cards',
         },
         {
-          syntax: '(t:flag OR t:elemental) e:void',
-          description: 'Find Void flags or elementals',
+          syntax: '(t:flag OR t:elemental) e:nether',
+          description: 'Find Nether flags or elementals',
         },
         {
-          syntax: 't:elemental e:steadfast c>=3',
-          description: 'Find expensive Steadfast elementals',
+          syntax: 't:elemental e:earth c>=3',
+          description: 'Find expensive Earth elementals',
         },
         {
-          syntax: 'r:rare -e:quintessence',
-          description: 'Find rare cards without Quintessence',
+          syntax: 'r:rare -e:aether',
+          description: 'Find rare cards without Aether',
         },
       ],
     },

--- a/src/utils/searchParser.js
+++ b/src/utils/searchParser.js
@@ -324,24 +324,56 @@ const matchesElementFilter = (card, element) => {
   const cardElements = getCardElements(card);
   const searchElement = element.toLowerCase();
   
-  // Map element names to symbols
+  // Map element names to symbols and abilities
   const elementMap = {
+    // Primary KONIVRER elements
+    'aether': '⬢',
+    'nether': '▢', 
+    'fire': '🜂',
+    'water': '🜄',
+    'earth': '🜃',
+    'air': '🜁',
+    // Legacy ability names (for backward compatibility)
     'brilliance': '⬢',
-    'gust': '🜁',
-    'inferno': '🜂',
-    'steadfast': '🜃',
-    'submerged': '🜄',
     'void': '▢',
+    'inferno': '🜂',
+    'submerged': '🜄',
+    'steadfast': '🜃',
+    'gust': '🜁',
     'quintessence': '✦'
   };
 
   const elementSymbol = elementMap[searchElement];
   
+  // Element name mappings for card data
+  const elementNameMap = {
+    'aether': ['brilliance', 'aether'],
+    'nether': ['void', 'nether'],
+    'fire': ['fire', 'inferno'],
+    'water': ['water', 'submerged'],
+    'earth': ['earth', 'steadfast'],
+    'air': ['air', 'gust']
+  };
+
   // Check if any card element matches (case-insensitive)
-  return cardElements.some(cardElement => 
-    cardElement.toLowerCase() === searchElement ||
-    cardElement === elementSymbol
-  );
+  return cardElements.some(cardElement => {
+    const cardElementLower = cardElement.toLowerCase();
+    
+    // Direct match
+    if (cardElementLower === searchElement) return true;
+    
+    // Symbol match
+    if (cardElement === elementSymbol) return true;
+    
+    // Check element name mappings
+    for (const [primaryElement, aliases] of Object.entries(elementNameMap)) {
+      if (searchElement === primaryElement && aliases.some(alias => cardElementLower === alias)) {
+        return true;
+      }
+    }
+    
+    return false;
+  });
 };
 
 /**


### PR DESCRIPTION
…Water, Earth, Air

- Updated search parser to map element names correctly
- Updated syntax guide with proper KONIVRER element names
- Added backward compatibility for legacy ability names
- Element mappings: aether↔brilliance, nether↔void, fire↔inferno, water↔submerged, earth↔steadfast, air↔gust