### PR TITLE
Update search system to properly distinguish keywords from elements

### DIFF
--- a/src/components/AdvancedSearch.jsx
+++ b/src/components/AdvancedSearch.jsx
@@ -37,10 +37,11 @@ const AdvancedSearch = ({ onSearch, onClose }) => {
     allowPartialTypes: true,
     selectedTypes: [],
 
-    // Colors & Identity
-    colors: [],
-    colorComparison: 'including', // including, exactly, at-most
-    colorIdentity: [],
+    // Elements & Keywords
+    elements: [],
+    elementComparison: 'including', // including, exactly, at-most
+    keywords: [],
+    keywordComparison: 'including', // including, exactly, at-most
 
     // Mana & Stats
     manaCost: '',
@@ -76,15 +77,25 @@ const AdvancedSearch = ({ onSearch, onClose }) => {
     'Planeswalker',
   ];
 
+  // KONIVRER Elements (for costs and Azoth generation)
   const elements = [
-    { name: 'Generic', symbol: '✡︎⃝', color: 'text-gray-400' },
-    { name: 'Brilliance', symbol: '⬢', color: 'text-yellow-400' },
-    { name: 'Gust', symbol: '🜁', color: 'text-blue-400' },
-    { name: 'Inferno', symbol: '🜂', color: 'text-red-400' },
-    { name: 'Steadfast', symbol: '🜃', color: 'text-green-400' },
-    { name: 'Submerged', symbol: '🜄', color: 'text-cyan-400' },
-    { name: 'Void', symbol: '▢', color: 'text-purple-400' },
-    { name: 'Quintessence', symbol: '✦', color: 'text-pink-400' },
+    { name: 'Fire', symbol: '△', color: 'text-red-400' },
+    { name: 'Water', symbol: '▽', color: 'text-blue-400' },
+    { name: 'Earth', symbol: '⊡', color: 'text-green-400' },
+    { name: 'Air', symbol: '△', color: 'text-cyan-400' },
+    { name: 'Aether', symbol: '○', color: 'text-purple-400' },
+    { name: 'Nether', symbol: '□', color: 'text-gray-600' },
+    { name: 'Generic', symbol: '⊗', color: 'text-gray-400' },
+  ];
+
+  // KONIVRER Keywords (special abilities, separate from elements)
+  const keywords = [
+    { name: 'Brilliance', symbol: '✦', color: 'text-yellow-400' },
+    { name: 'Void', symbol: '◯', color: 'text-purple-400' },
+    { name: 'Gust', symbol: '≋', color: 'text-blue-400' },
+    { name: 'Submerged', symbol: '≈', color: 'text-cyan-400' },
+    { name: 'Inferno', symbol: '※', color: 'text-red-400' },
+    { name: 'Steadfast', symbol: '⬢', color: 'text-green-400' },
   ];
 
   const rarities = ['Common', 'Uncommon', 'Rare', 'Mythic', 'Legendary'];

--- a/src/components/KonivrERSyntaxGuide.jsx
+++ b/src/components/KonivrERSyntaxGuide.jsx
@@ -108,35 +108,35 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
       id: 'elements',
       title: 'Element Searches',
       icon: Palette,
-      description: 'Search by KONIVRER elements and mana costs',
+      description: 'Search by KONIVRER elements (resource costs)',
       examples: [
         {
-          syntax: 'e:brilliance',
-          description: 'Find cards with Brilliance element (⬢)',
+          syntax: 'e:fire',
+          description: 'Find cards with Fire element (△)',
         },
         {
-          syntax: 'e:gust',
-          description: 'Find cards with Gust element (🜁)',
+          syntax: 'e:water',
+          description: 'Find cards with Water element (▽)',
         },
         {
-          syntax: 'e:inferno',
-          description: 'Find cards with Inferno element (🜂)',
+          syntax: 'e:earth',
+          description: 'Find cards with Earth element (⊡)',
         },
         {
-          syntax: 'e:steadfast',
-          description: 'Find cards with Steadfast element (🜃)',
+          syntax: 'e:air',
+          description: 'Find cards with Air element (△)',
         },
         {
-          syntax: 'e:submerged',
-          description: 'Find cards with Submerged element (🜄)',
+          syntax: 'e:aether',
+          description: 'Find cards with Aether element (○)',
         },
         {
-          syntax: 'e:void',
-          description: 'Find cards with Void element (▢)',
+          syntax: 'e:nether',
+          description: 'Find cards with Nether element (□)',
         },
         {
-          syntax: 'e:quintessence',
-          description: 'Find cards with Quintessence element (✦)',
+          syntax: 'e:generic',
+          description: 'Find cards with Generic element (⊗)',
         },
         {
           syntax: 'e&gt;=2',
@@ -145,9 +145,45 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
       ],
     },
     {
+      id: 'keywords',
+      title: 'Keyword Searches',
+      icon: Zap,
+      description: 'Search by KONIVRER keywords (special abilities)',
+      examples: [
+        {
+          syntax: 'k:brilliance',
+          description: 'Find cards with Brilliance keyword (✦)',
+        },
+        {
+          syntax: 'k:void',
+          description: 'Find cards with Void keyword (◯)',
+        },
+        {
+          syntax: 'k:gust',
+          description: 'Find cards with Gust keyword (≋)',
+        },
+        {
+          syntax: 'k:submerged',
+          description: 'Find cards with Submerged keyword (≈)',
+        },
+        {
+          syntax: 'k:inferno',
+          description: 'Find cards with Inferno keyword (※)',
+        },
+        {
+          syntax: 'k:steadfast',
+          description: 'Find cards with Steadfast keyword (⬢)',
+        },
+        {
+          syntax: 'k&gt;=2',
+          description: 'Find cards with 2 or more keywords',
+        },
+      ],
+    },
+    {
       id: 'mana',
       title: 'Mana Cost Searches',
-      icon: Zap,
+      icon: DollarSign,
       description: 'Search by mana costs and converted mana cost',
       examples: [
         {
@@ -267,7 +303,7 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
       description: 'Complex search operators and combinations',
       examples: [
         {
-          syntax: '(t:familiar OR t:spell) e:brilliance',
+          syntax: '(t:familiar OR t:spell) k:brilliance',
           description: 'Combine searches with parentheses',
         },
         {
@@ -444,8 +480,8 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
             <p className="text-gray-400 text-xs mt-1">Card Types</p>
           </div>
           <div className="text-center">
-            <code className="text-blue-300 font-mono text-sm">e:brilliance</code>
-            <p className="text-gray-400 text-xs mt-1">Elements</p>
+            <code className="text-blue-300 font-mono text-sm">k:brilliance</code>
+            <p className="text-gray-400 text-xs mt-1">Keywords</p>
           </div>
           <div className="text-center">
             <code className="text-green-300 font-mono text-sm">cmc:3</code>
@@ -474,8 +510,8 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
               Pro Tips
             </h4>
             <ul className="text-gray-300 text-sm space-y-1">
-              <li>• Combine multiple criteria: <code className="text-purple-300">t:familiar e:brilliance cmc:3</code></li>
-              <li>• Use parentheses for complex logic: <code className="text-purple-300">(t:spell OR t:artifact) e:void</code></li>
+              <li>• Combine multiple criteria: <code className="text-purple-300">t:familiar k:brilliance cmc:3</code></li>
+              <li>• Use parentheses for complex logic: <code className="text-purple-300">(t:spell OR t:artifact) k:void</code></li>
               <li>• Exclude with minus: <code className="text-purple-300">dragon -t:token</code></li>
               <li>• Use quotes for exact phrases: <code className="text-purple-300">"enters the battlefield"</code></li>
             </ul>


### PR DESCRIPTION
- Fix AdvancedSearch component to separate keywords from elements
- Update KonivrERSyntaxGuide with separate sections for keywords (k:) vs elements (e:)
- Enhance searchParser to handle both keyword and element filtering
- Add proper keyword extraction and matching functions
- Remove conflation of keywords with elements in search results
- Update examples and documentation to use correct syntax

Search syntax:
- Elements: e:fire, e:water, e:earth, e:air, e:aether, e:nether, e:generic
- Keywords: k:brilliance, k:void, k:gust, k:submerged, k:inferno, k:steadfast

This completes the separation between the two distinct game systems.