### PR TITLE
Update Quick Reference to follow new format

### DIFF
--- a/src/components/KonivrERSyntaxGuide.jsx
+++ b/src/components/KonivrERSyntaxGuide.jsx
@@ -404,26 +404,83 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
       {/* Quick Reference */}
       <div className="p-6 border-b border-white/20 bg-gradient-to-r from-purple-500/10 to-pink-500/10">
         <h3 className="text-lg font-semibold text-white mb-3">Quick Reference</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
-          <div className="text-center">
-            <code className="text-purple-300 font-mono text-sm">t:familiar</code>
-            <p className="text-gray-400 text-xs mt-1">Card Types</p>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <code className="text-purple-300 font-mono text-sm bg-purple-500/20 px-2 py-1 rounded">
+                t:familiar | type:familiar
+              </code>
+            </div>
+            <p className="text-gray-300 text-sm mb-2">Search by card types</p>
+            <div className="bg-blue-500/10 rounded p-2 border border-blue-500/20">
+              <p className="text-blue-300 text-xs font-semibold mb-1">Viable Words:</p>
+              <code className="text-blue-200 text-xs">familiar, spell, artifact, elemental, legendary, token</code>
+            </div>
           </div>
-          <div className="text-center">
-            <code className="text-orange-300 font-mono text-sm">e:fire</code>
-            <p className="text-gray-400 text-xs mt-1">Elements (Cost)</p>
+          
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <code className="text-orange-300 font-mono text-sm bg-orange-500/20 px-2 py-1 rounded">
+                e:fire | element:fire
+              </code>
+            </div>
+            <p className="text-gray-300 text-sm mb-2">Search by mana cost elements</p>
+            <div className="bg-blue-500/10 rounded p-2 border border-blue-500/20">
+              <p className="text-blue-300 text-xs font-semibold mb-1">Viable Words:</p>
+              <code className="text-blue-200 text-xs">fire, water, earth, air, aether, nether, generic</code>
+            </div>
           </div>
-          <div className="text-center">
-            <code className="text-blue-300 font-mono text-sm">k:brilliance</code>
-            <p className="text-gray-400 text-xs mt-1">Keywords (Abilities)</p>
+          
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <code className="text-blue-300 font-mono text-sm bg-blue-500/20 px-2 py-1 rounded">
+                k:brilliance | keyword:brilliance
+              </code>
+            </div>
+            <p className="text-gray-300 text-sm mb-2">Search by keyword abilities</p>
+            <div className="bg-blue-500/10 rounded p-2 border border-blue-500/20">
+              <p className="text-blue-300 text-xs font-semibold mb-1">Viable Words:</p>
+              <code className="text-blue-200 text-xs">brilliance, void, gust, submerged, inferno, steadfast</code>
+            </div>
           </div>
-          <div className="text-center">
-            <code className="text-green-300 font-mono text-sm">cmc:3</code>
-            <p className="text-gray-400 text-xs mt-1">Mana Cost</p>
+          
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <code className="text-green-300 font-mono text-sm bg-green-500/20 px-2 py-1 rounded">
+                cmc:3 | mv:3 | cost:3
+              </code>
+            </div>
+            <p className="text-gray-300 text-sm mb-2">Search by mana cost</p>
+            <div className="bg-blue-500/10 rounded p-2 border border-blue-500/20">
+              <p className="text-blue-300 text-xs font-semibold mb-1">Viable Words:</p>
+              <code className="text-blue-200 text-xs">Any number (0, 1, 2, 3, 4, 5+)</code>
+            </div>
           </div>
-          <div className="text-center">
-            <code className="text-yellow-300 font-mono text-sm">pow&gt;=3</code>
-            <p className="text-gray-400 text-xs mt-1">Power/Toughness</p>
+          
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <code className="text-yellow-300 font-mono text-sm bg-yellow-500/20 px-2 py-1 rounded">
+                pow:3 | power:3 | p:3
+              </code>
+            </div>
+            <p className="text-gray-300 text-sm mb-2">Search by power/toughness</p>
+            <div className="bg-blue-500/10 rounded p-2 border border-blue-500/20">
+              <p className="text-blue-300 text-xs font-semibold mb-1">Viable Words:</p>
+              <code className="text-blue-200 text-xs">Any number (0, 1, 2, 3, 4, 5+) or *</code>
+            </div>
+          </div>
+          
+          <div className="bg-white/5 rounded-lg p-3 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <code className="text-pink-300 font-mono text-sm bg-pink-500/20 px-2 py-1 rounded">
+                r:rare | rarity:rare
+              </code>
+            </div>
+            <p className="text-gray-300 text-sm mb-2">Search by rarity</p>
+            <div className="bg-blue-500/10 rounded p-2 border border-blue-500/20">
+              <p className="text-blue-300 text-xs font-semibold mb-1">Viable Words:</p>
+              <code className="text-blue-200 text-xs">common, uncommon, rare, mythic, legendary</code>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Replace simple syntax examples with comprehensive cards
- Each card shows syntax variations (using | separator)
- Include clear descriptions of what each syntax does
- Add 'Viable Words' section for each syntax type
- Show all 6 main search categories: types, elements, keywords, mana cost, power/toughness, rarity
- Use consistent styling with the detailed sections
- Make Quick Reference much more informative and practical

Now the Quick Reference follows the same 'Syntax | Variations, Description, Viable Words' format as requested.