### PR TITLE
Simplify card types to only 'elemental' and 'flag'

### DIFF
--- a/src/components/KonivrERSyntaxGuide.jsx
+++ b/src/components/KonivrERSyntaxGuide.jsx
@@ -87,12 +87,12 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
       description: 'Search by card types and subtypes',
       examples: [
         {
-          syntax: 't:familiar | type:familiar',
+          syntax: 't:elemental | type:elemental',
           description: 'Search for cards by their type',
-          viableWords: 'familiar, spell, artifact, elemental, legendary, token, land, enchantment, instant, sorcery'
+          viableWords: 'elemental, flag'
         },
         {
-          syntax: 't:"legendary familiar"',
+          syntax: 't:"elemental flag"',
           description: 'Search for cards with multiple type words (use quotes)',
           viableWords: 'Any combination of type words in quotes'
         },
@@ -413,12 +413,12 @@ const KonivrERSyntaxGuide = ({ isExpanded = false, onToggle }) => {
         <div className="space-y-3">
           <div className="bg-white/5 rounded-lg p-4 border border-white/10">
             <h4 className="text-purple-300 font-semibold mb-2">Syntax and Variations</h4>
-            <code className="text-purple-300 font-mono text-sm bg-purple-500/20 px-2 py-1 rounded mr-2">t:familiar</code>
-            <code className="text-purple-300 font-mono text-sm bg-purple-500/20 px-2 py-1 rounded">type:familiar</code>
+            <code className="text-purple-300 font-mono text-sm bg-purple-500/20 px-2 py-1 rounded mr-2">t:elemental</code>
+            <code className="text-purple-300 font-mono text-sm bg-purple-500/20 px-2 py-1 rounded">type:elemental</code>
             <h4 className="text-white font-semibold mt-3 mb-2">Description of Syntax</h4>
             <p className="text-gray-300 text-sm">Search for cards by their type</p>
             <h4 className="text-blue-300 font-semibold mt-3 mb-2">Acceptable Words for the Syntax</h4>
-            <p className="text-blue-200 text-sm">familiar, spell, artifact, elemental, legendary, token, land, enchantment, instant, sorcery</p>
+            <p className="text-blue-200 text-sm">elemental, flag</p>
           </div>
           
           <div className="bg-white/5 rounded-lg p-4 border border-white/10">

--- a/src/pages/SyntaxGuide.jsx
+++ b/src/pages/SyntaxGuide.jsx
@@ -76,9 +76,9 @@ const SyntaxGuide = () => {
       description: 'Search by card types and subtypes',
       examples: [
         {
-          syntax: 't:familiar | type:familiar',
+          syntax: 't:elemental | type:elemental',
           description: 'Search for cards by their type',
-          viableWords: 'familiar, spell, artifact, elemental, legendary, token, land, enchantment, instant, sorcery'
+          viableWords: 'elemental, flag'
         },
       ],
     },
@@ -190,13 +190,13 @@ const SyntaxGuide = () => {
             <div className="bg-slate-700/50 rounded-lg p-4 border border-slate-600/50">
               <h4 className="text-purple-300 font-semibold mb-2">Syntax and Variations</h4>
               <div className="flex flex-wrap gap-2 mb-3">
-                <code className="text-purple-300 font-mono text-sm bg-slate-900/50 px-2 py-1 rounded">t:familiar</code>
-                <code className="text-purple-300 font-mono text-sm bg-slate-900/50 px-2 py-1 rounded">type:familiar</code>
+                <code className="text-purple-300 font-mono text-sm bg-slate-900/50 px-2 py-1 rounded">t:elemental</code>
+                <code className="text-purple-300 font-mono text-sm bg-slate-900/50 px-2 py-1 rounded">type:elemental</code>
               </div>
               <h4 className="text-white font-semibold mb-2">Description of Syntax</h4>
               <p className="text-gray-300 text-sm mb-3">Search for cards by their type</p>
               <h4 className="text-blue-300 font-semibold mb-2">Acceptable Words for the Syntax</h4>
-              <p className="text-blue-200 text-sm">familiar, spell, artifact, elemental, legendary, token, land, enchantment, instant, sorcery</p>
+              <p className="text-blue-200 text-sm">elemental, flag</p>
             </div>
             
             <div className="bg-slate-700/50 rounded-lg p-4 border border-slate-600/50">


### PR DESCRIPTION
Changes:
- Updated both syntax guide files to only show 'elemental' and 'flag' as valid card types
- Changed syntax examples from 't:familiar' to 't:elemental'
- Updated Quick Reference sections to reflect the simplified type system
- Removed all other card types (familiar, spell, artifact, legendary, token, land, enchantment, instant, sorcery)
- Updated multi-type example from 'legendary familiar' to 'elemental flag'

This simplifies the KONIVRER card type system to just two core types.