### PR TITLE
Replace geometric symbols with alchemical symbols for classic elements

### DIFF
--- a/src/components/AdvancedSearch.jsx
+++ b/src/components/AdvancedSearch.jsx
@@ -77,12 +77,12 @@ const AdvancedSearch = ({ onSearch, onClose }) => {
     'Planeswalker',
   ];
 
-  // KONIVRER Elements (for costs and Azoth generation)
+  // KONIVRER Elements (for costs and Azoth generation) - using alchemical symbols for classic elements
   const elements = [
-    { name: 'Fire', symbol: '△', color: 'text-red-400' },
-    { name: 'Water', symbol: '▽', color: 'text-blue-400' },
-    { name: 'Earth', symbol: '⊡', color: 'text-green-400' },
-    { name: 'Air', symbol: '△', color: 'text-cyan-400' },
+    { name: 'Fire', symbol: '🜂', color: 'text-red-400' },
+    { name: 'Water', symbol: '🜄', color: 'text-blue-400' },
+    { name: 'Earth', symbol: '🜃', color: 'text-green-400' },
+    { name: 'Air', symbol: '🜁', color: 'text-cyan-400' },
     { name: 'Aether', symbol: '○', color: 'text-purple-400' },
     { name: 'Nether', symbol: '□', color: 'text-gray-600' },
     { name: 'Generic', symbol: '⊗', color: 'text-gray-400' },

--- a/src/components/ScryfalLikeAdvancedSearch.jsx
+++ b/src/components/ScryfalLikeAdvancedSearch.jsx
@@ -83,12 +83,12 @@ const ScryfalLikeAdvancedSearch = () => {
   const [searchResults, setSearchResults] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
 
-  // KONIVRER-specific adaptations
+  // KONIVRER-specific adaptations - using alchemical symbols for classic elements
   const konivrElements = [
-    { key: 'fire', label: 'Fire', symbol: '△', color: '#FF4500' },
-    { key: 'water', label: 'Water', symbol: '▽', color: '#4169E1' },
-    { key: 'earth', label: 'Earth', symbol: '⊡', color: '#8B4513' },
-    { key: 'air', label: 'Air', symbol: '△', color: '#87CEEB' },
+    { key: 'fire', label: 'Fire', symbol: '🜂', color: '#FF4500' },
+    { key: 'water', label: 'Water', symbol: '🜄', color: '#4169E1' },
+    { key: 'earth', label: 'Earth', symbol: '🜃', color: '#8B4513' },
+    { key: 'air', label: 'Air', symbol: '🜁', color: '#87CEEB' },
     { key: 'aether', label: 'Aether', symbol: '○', color: '#FFD700' },
     { key: 'nether', label: 'Nether', symbol: '□', color: '#4B0082' },
     { key: 'generic', label: 'Generic', symbol: '⊗', color: '#696969' }

--- a/src/components/game/KonivrERCard.jsx
+++ b/src/components/game/KonivrERCard.jsx
@@ -43,22 +43,22 @@ const KonivrERCard = ({
   onDragStart,
   className = ''
 }) => {
-  // Element symbols and colors
+  // Element symbols and colors - using alchemical symbols for classic elements
   const elementConfig = {
-    Fire: { icon: Flame, symbol: '△', color: 'text-red-400', bg: 'bg-red-900/30' },
-    Water: { icon: Droplets, symbol: '▽', color: 'text-blue-400', bg: 'bg-blue-900/30' },
-    Earth: { icon: Mountain, symbol: '⊡', color: 'text-green-400', bg: 'bg-green-900/30' },
-    Air: { icon: Wind, symbol: '△', color: 'text-gray-300', bg: 'bg-gray-700/30' },
+    Fire: { icon: Flame, symbol: '🜂', color: 'text-red-400', bg: 'bg-red-900/30' },
+    Water: { icon: Droplets, symbol: '🜄', color: 'text-blue-400', bg: 'bg-blue-900/30' },
+    Earth: { icon: Mountain, symbol: '🜃', color: 'text-green-400', bg: 'bg-green-900/30' },
+    Air: { icon: Wind, symbol: '🜁', color: 'text-gray-300', bg: 'bg-gray-700/30' },
     Quintessence: { icon: Sparkles, symbol: '○', color: 'text-purple-400', bg: 'bg-purple-900/30' },
     Void: { icon: Square, symbol: '□', color: 'text-gray-800', bg: 'bg-gray-900/50' },
     Brilliance: { icon: Star, symbol: '☉', color: 'text-yellow-400', bg: 'bg-yellow-900/30' },
-    Submerged: { icon: Droplets, symbol: '▽', color: 'text-cyan-400', bg: 'bg-cyan-900/30' },
+    Submerged: { icon: Droplets, symbol: '🜄', color: 'text-cyan-400', bg: 'bg-cyan-900/30' },
     Neutral: { icon: Circle, symbol: '⊗', color: 'text-gray-400', bg: 'bg-gray-800/30' },
     // Legacy support for old format
-    fire: { icon: Flame, symbol: '△', color: 'text-red-400', bg: 'bg-red-900/30' },
-    water: { icon: Droplets, symbol: '▽', color: 'text-blue-400', bg: 'bg-blue-900/30' },
-    earth: { icon: Mountain, symbol: '⊡', color: 'text-green-400', bg: 'bg-green-900/30' },
-    air: { icon: Wind, symbol: '△', color: 'text-gray-300', bg: 'bg-gray-700/30' },
+    fire: { icon: Flame, symbol: '🜂', color: 'text-red-400', bg: 'bg-red-900/30' },
+    water: { icon: Droplets, symbol: '🜄', color: 'text-blue-400', bg: 'bg-blue-900/30' },
+    earth: { icon: Mountain, symbol: '🜃', color: 'text-green-400', bg: 'bg-green-900/30' },
+    air: { icon: Wind, symbol: '🜁', color: 'text-gray-300', bg: 'bg-gray-700/30' },
     aether: { icon: Sparkles, symbol: '○', color: 'text-purple-400', bg: 'bg-purple-900/30' },
     nether: { icon: Square, symbol: '□', color: 'text-gray-800', bg: 'bg-gray-900/50' },
     generic: { icon: Circle, symbol: '⊗', color: 'text-gray-400', bg: 'bg-gray-800/30' }

--- a/src/components/game/KonivrERGameBoard.jsx
+++ b/src/components/game/KonivrERGameBoard.jsx
@@ -47,12 +47,12 @@ const KonivrERGameBoard = ({
   const [dropZone, setDropZone] = useState(null);
   const boardRef = useRef(null);
 
-  // Element symbols mapping
+  // Element symbols mapping - using alchemical symbols for classic elements
   const elementSymbols = {
-    fire: { icon: Flame, symbol: '△', color: 'text-red-400' },
-    water: { icon: Droplets, symbol: '▽', color: 'text-blue-400' },
-    earth: { icon: Mountain, symbol: '⊡', color: 'text-green-400' },
-    air: { icon: Wind, symbol: '△', color: 'text-gray-300' },
+    fire: { icon: Flame, symbol: '🜂', color: 'text-red-400' },
+    water: { icon: Droplets, symbol: '🜄', color: 'text-blue-400' },
+    earth: { icon: Mountain, symbol: '🜃', color: 'text-green-400' },
+    air: { icon: Wind, symbol: '🜁', color: 'text-gray-300' },
     aether: { icon: Sparkles, symbol: '○', color: 'text-purple-400' },
     nether: { icon: Square, symbol: '□', color: 'text-gray-800' },
     generic: { icon: Circle, symbol: '⊗', color: 'text-gray-400' }

--- a/src/engine/elementalSystem.js
+++ b/src/engine/elementalSystem.js
@@ -14,15 +14,15 @@ export const ELEMENTS = {
   GENERIC: 'generic'
 };
 
-// Element symbols
+// Element symbols - using alchemical symbols for classic elements
 export const ELEMENT_SYMBOLS = {
-  [ELEMENTS.FIRE]: '△',
-  [ELEMENTS.WATER]: '▽',
-  [ELEMENTS.EARTH]: '⊡',
-  [ELEMENTS.AIR]: '△',
-  [ELEMENTS.AETHER]: '○',
-  [ELEMENTS.NETHER]: '□',
-  [ELEMENTS.GENERIC]: '⊗'
+  [ELEMENTS.FIRE]: '🜂',      // Alchemical symbol for fire
+  [ELEMENTS.WATER]: '🜄',     // Alchemical symbol for water
+  [ELEMENTS.EARTH]: '🜃',     // Alchemical symbol for earth
+  [ELEMENTS.AIR]: '🜁',       // Alchemical symbol for air
+  [ELEMENTS.AETHER]: '○',     // Circle for aether
+  [ELEMENTS.NETHER]: '□',     // Square for nether
+  [ELEMENTS.GENERIC]: '⊗'     // Circled times for generic
 };
 
 // Elemental advantages

--- a/src/engine/keywordSystem.js
+++ b/src/engine/keywordSystem.js
@@ -27,14 +27,14 @@ export const KEYWORD_SYMBOLS = {
   [KEYWORDS.VOID]: '◯'
 };
 
-// Keyword descriptions
+// Keyword descriptions - using alchemical symbols for classic elements
 export const KEYWORD_DESCRIPTIONS = {
   [KEYWORDS.AMALGAM]: 'Choose keyword and element when played, or element when used as Azoth',
   [KEYWORDS.BRILLIANCE]: 'Place target Familiar with +1 Counters or Spell with Strength ≤ ○ on bottom of life cards',
-  [KEYWORDS.GUST]: 'Return target Familiar with +1 Counters or Spell with Strength ≤ △ to owner\'s hand',
-  [KEYWORDS.INFERNO]: 'After damage is dealt to target card, add damage ≤ △ used to pay for this card\'s Strength',
-  [KEYWORDS.STEADFAST]: 'Redirect damage ≤ ⊡ used to pay for this card\'s Strength to this card\'s Strength',
-  [KEYWORDS.SUBMERGED]: 'Place target Familiar with +1 Counters or Spell with Strength ≤ ▽ below top of owner\'s deck',
+  [KEYWORDS.GUST]: 'Return target Familiar with +1 Counters or Spell with Strength ≤ 🜁 to owner\'s hand',
+  [KEYWORDS.INFERNO]: 'After damage is dealt to target card, add damage ≤ 🜂 used to pay for this card\'s Strength',
+  [KEYWORDS.STEADFAST]: 'Redirect damage ≤ 🜃 used to pay for this card\'s Strength to this card\'s Strength',
+  [KEYWORDS.SUBMERGED]: 'Place target Familiar with +1 Counters or Spell with Strength ≤ 🜄 below top of owner\'s deck',
   [KEYWORDS.QUINTESSENCE]: 'This card can\'t be played as a Familiar. While in Azoth row, produces any Azoth type',
   [KEYWORDS.VOID]: 'Remove target card from the game'
 };
@@ -163,7 +163,7 @@ function applyBrillianceEffect(gameState, playerId, card) {
  * @returns {Object} Updated game state
  */
 function applyGustEffect(gameState, playerId, card) {
-  // Gust: Return target Familiar with +1 Counters or Spell with Strength ≤ △ to owner's hand
+  // Gust: Return target Familiar with +1 Counters or Spell with Strength ≤ 🜁 to owner's hand
   const fireUsed = getElementUsedForCard(gameState, playerId, card, 'fire');
   
   gameState.waitingForInput = true;
@@ -186,7 +186,7 @@ function applyGustEffect(gameState, playerId, card) {
  * @returns {Object} Updated game state
  */
 function applyInfernoEffect(gameState, playerId, card) {
-  // Inferno: After damage is dealt to target card, add damage ≤ △ used to pay for this card's Strength
+  // Inferno: After damage is dealt to target card, add damage ≤ 🜂 used to pay for this card's Strength
   const fireUsed = getElementUsedForCard(gameState, playerId, card, 'fire');
   
   // This is a triggered ability that activates after damage is dealt
@@ -207,7 +207,7 @@ function applyInfernoEffect(gameState, playerId, card) {
  * @returns {Object} Updated game state
  */
 function applySteadfastEffect(gameState, playerId, card) {
-  // Steadfast: Redirect damage ≤ ⊡ used to pay for this card's Strength to this card's Strength
+  // Steadfast: Redirect damage ≤ 🜃 used to pay for this card's Strength to this card's Strength
   const earthUsed = getElementUsedForCard(gameState, playerId, card, 'earth');
   
   // This is a replacement effect that redirects damage
@@ -228,7 +228,7 @@ function applySteadfastEffect(gameState, playerId, card) {
  * @returns {Object} Updated game state
  */
 function applySubmergedEffect(gameState, playerId, card) {
-  // Submerged: Place target Familiar with +1 Counters or Spell with Strength ≤ ▽ below top of owner's deck
+  // Submerged: Place target Familiar with +1 Counters or Spell with Strength ≤ 🜄 below top of owner's deck
   const waterUsed = getElementUsedForCard(gameState, playerId, card, 'water');
   
   gameState.waitingForInput = true;
@@ -444,7 +444,7 @@ function getGustValidTargets(gameState, maxStrength) {
     player.field.forEach(card => {
       if ((card.type === 'Familiar' && card.counters > 0) || 
           (card.type === 'Spell' && card.strength <= maxStrength)) {
-        // Don't affect Water (▽) cards
+        // Don't affect Water (🜄) cards
         if (!card.elements || !card.elements.water) {
           validTargets.push({ card, playerIndex, zone: 'field' });
         }
@@ -469,7 +469,7 @@ function getSubmergedValidTargets(gameState, maxStrength) {
     player.field.forEach(card => {
       if ((card.type === 'Familiar' && card.counters > 0) || 
           (card.type === 'Spell' && card.strength <= maxStrength)) {
-        // Don't affect Fire (△) cards
+        // Don't affect Fire (🜂) cards
         if (!card.elements || !card.elements.fire) {
           validTargets.push({ card, playerIndex, zone: 'field' });
         }

--- a/src/pages/KonivrERDemo.jsx
+++ b/src/pages/KonivrERDemo.jsx
@@ -399,14 +399,14 @@ const KonivrERDemo = () => {
                 <div>
                   <h4 className="text-lg font-semibold text-green-400 mb-2">Elemental System</h4>
                   <ul className="text-gray-300 space-y-1 text-sm">
-                    <li>• Fire (△) - Aggressive, direct damage</li>
-                    <li>• Water (▽) - Flow, healing, flexibility</li>
-                    <li>• Earth (⊡) - Stability, defense</li>
-                    <li>• Air (△) - Speed, evasion</li>
+                    <li>• Fire (🜂) - Aggressive, direct damage</li>
+                    <li>• Water (🜄) - Flow, healing, flexibility</li>
+                    <li>• Earth (🜃) - Stability, defense</li>
+                    <li>• Air (🜁) - Speed, evasion</li>
                     <li>• Quintessence (○) - Transformation, power</li>
                     <li>• Void (□) - Darkness, removal</li>
                     <li>• Brilliance (☉) - Light, enhancement</li>
-                    <li>• Submerged (▽) - Deep water, hidden</li>
+                    <li>• Submerged (🜄) - Deep water, hidden</li>
                   </ul>
                 </div>
 

--- a/src/utils/searchParser.js
+++ b/src/utils/searchParser.js
@@ -338,12 +338,12 @@ const matchesElementFilter = (card, element) => {
   const cardElements = getCardElements(card);
   const searchElement = element.toLowerCase();
   
-  // Map ACTUAL element names to symbols (not keywords!)
+  // Map ACTUAL element names to symbols (not keywords!) - using alchemical symbols for classic elements
   const elementMap = {
-    'fire': '△',
-    'water': '▽',
-    'earth': '⊡',
-    'air': '△',
+    'fire': '🜂',
+    'water': '🜄',
+    'earth': '🜃',
+    'air': '🜁',
     'aether': '○',
     'nether': '□',
     'generic': '⊗'


### PR DESCRIPTION
- Fire: △ → 🜂 (alchemical fire symbol)
- Water: ▽ → 🜄 (alchemical water symbol)
- Earth: ⊡ → 🜃 (alchemical earth symbol)
- Air: △ → 🜁 (alchemical air symbol)
- Keep existing symbols for Aether (○), Nether (□), and Generic (⊗)

Updated across all components:
- elementalSystem.js: Core element symbol definitions
- ScryfalLikeAdvancedSearch.jsx: Search interface elements
- AdvancedSearch.jsx: Advanced search elements
- KonivrERCard.jsx: Card display elements
- KonivrERGameBoard.jsx: Game board elements
- KonivrERDemo.jsx: Demo page element descriptions
- searchParser.js: Search parsing element mapping
- keywordSystem.js: Keyword descriptions and comments

This provides more authentic alchemical symbolism while maintaining the existing non-classical element symbols.