### PR TITLE
Separate Play and Tournaments Pages with Dedicated Navigation

### DIFF
--- a/src/core/AllInOne-simple.tsx
+++ b/src/core/AllInOne-simple.tsx
@@ -116,6 +116,22 @@ const Navigation: React.FC = () => {
         >
           Play
         </Link>
+        <Link 
+          to="/events" 
+          style={{
+            color: '#f2e8c9',
+            textDecoration: 'none',
+            fontSize: '18px',
+            fontWeight: 'bold',
+            padding: '8px 12px',
+            borderRadius: '4px',
+            transition: 'background-color 0.3s'
+          }}
+          onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#6b4423'}
+          onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
+        >
+          Tournaments
+        </Link>
       </div>
 
       <div>
@@ -729,7 +745,7 @@ const DecksPage: React.FC = () => {
   );
 };
 
-// Play Page (Game Center & Tournaments)
+// Play Page (Game Center)
 const PlayPage: React.FC = () => {
   const gameOptions = [
     {
@@ -754,33 +770,6 @@ const PlayPage: React.FC = () => {
     }
   ];
 
-  const upcomingEvents = [
-    {
-      name: 'Weekly Championship',
-      date: 'Starts in 2 days',
-      description: 'Compete for weekly prizes and ranking points',
-      status: 'Open Registration'
-    },
-    {
-      name: 'Monthly Grand Prix',
-      date: 'Registration open',
-      description: 'Monthly tournament with exclusive card rewards',
-      status: 'Registration Open'
-    },
-    {
-      name: 'Seasonal Championship',
-      date: 'Qualifiers ongoing',
-      description: 'The biggest tournament of the season',
-      status: 'Qualifiers'
-    },
-    {
-      name: 'Beginner Tournament',
-      date: 'Every Sunday',
-      description: 'Perfect for new players to learn and compete',
-      status: 'Weekly Event'
-    }
-  ];
-
   return (
     <div style={{ 
       padding: '40px 20px', 
@@ -788,7 +777,6 @@ const PlayPage: React.FC = () => {
       background: '#f2e8c9',
       minHeight: '100vh'
     }}>
-      {/* Game Center Section */}
       <h1 style={{ 
         marginBottom: '30px', 
         color: '#3a2921',
@@ -860,11 +848,47 @@ const PlayPage: React.FC = () => {
           Use your mana wisely to play cards and control the battlefield!
         </p>
       </div>
+    </div>
+  );
+};
 
-      {/* Tournaments & Events Section */}
+// Events Page (Tournaments)
+const EventsPage: React.FC = () => {
+  const upcomingEvents = [
+    {
+      name: 'Weekly Championship',
+      date: 'Starts in 2 days',
+      description: 'Compete for weekly prizes and ranking points',
+      status: 'Open Registration'
+    },
+    {
+      name: 'Monthly Grand Prix',
+      date: 'Registration open',
+      description: 'Monthly tournament with exclusive card rewards',
+      status: 'Registration Open'
+    },
+    {
+      name: 'Seasonal Championship',
+      date: 'Qualifiers ongoing',
+      description: 'The biggest tournament of the season',
+      status: 'Qualifiers'
+    },
+    {
+      name: 'Beginner Tournament',
+      date: 'Every Sunday',
+      description: 'Perfect for new players to learn and compete',
+      status: 'Weekly Event'
+    }
+  ];
+
+  return (
+    <div style={{ 
+      padding: '40px 20px',
+      background: '#f2e8c9',
+      minHeight: '100vh'
+    }}>
       <h1 style={{ 
         textAlign: 'center', 
-        marginTop: '60px',
         marginBottom: '30px', 
         color: '#3a2921',
         fontSize: '36px'
@@ -967,6 +991,7 @@ const AllInOneApp: React.FC = () => {
             <Route path="/cards" element={<CardsPage />} />
             <Route path="/decks" element={<DecksPage />} />
             <Route path="/play" element={<PlayPage />} />
+            <Route path="/events" element={<EventsPage />} />
           </Routes>
         </main>
       </div>


### PR DESCRIPTION
## Description
This PR creates separate pages for Play and Tournaments features, each with their own dedicated navigation link. The navigation menu now includes both "Play" and "Tournaments" links that point to their respective pages.

## Changes Made
- Added "Tournaments" link to the navigation menu
- Created separate PlayPage component focused only on game features
- Created separate EventsPage component focused only on tournament features
- Added route for /events to access the Tournaments page
- Maintained all functionality from both pages

## Testing
- Verified that the Play page displays only game options and rules
- Verified that the Tournaments page displays only tournament information and rules
- Confirmed that the navigation menu shows both Play and Tournaments links
- Tested navigation between all pages

## Screenshots
The application now has separate pages for Play and Tournaments, each accessible from the navigation menu.

## Additional Notes
This change provides a clearer separation of concerns between playing the game and participating in tournaments, making the interface more intuitive for users.

@MichaelWBrennan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2b9e9c96feef4195b824bb7a3507bca3)