### PR TITLE
Merge Cards and Search pages, remove Search from header

### DIFF
--- a/src/components/MergedCardsPage.tsx
+++ b/src/components/MergedCardsPage.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import UnifiedCardSearch from './UnifiedCardSearch';
+import { KONIVRER_CARDS } from '../data/cards';
+
+// Types
+interface Card {
+  id: string; 
+  name: string; 
+  cost: number; 
+  type: 'Familiar' | 'Flag';
+  description: string; 
+  rarity: 'Common' | 'Uncommon' | 'Rare';
+  elements: string[]; 
+  keywords: string[]; 
+  strength?: number; 
+  artist?: string;
+}
+
+interface SearchResult {
+  cards: Card[];
+  totalCount: number;
+  searchTime: number;
+  warnings?: string[];
+}
+
+const MergedCardsPage: React.FC = () => {
+  const allCards: Card[] = KONIVRER_CARDS;
+  
+  const [searchResults, setSearchResults] = useState<SearchResult>({ 
+    cards: [], 
+    totalCount: 0, 
+    searchTime: 0 
+  });
+
+  const handleSearchResults = (results: SearchResult) => {
+    setSearchResults(results);
+  };
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '1200px', margin: '0 auto' }}>
+      <h1 style={{ color: '#d4af37', marginBottom: '30px', textAlign: 'center' }}>
+        Card Database & Search
+      </h1>
+      
+      <UnifiedCardSearch 
+        cards={allCards}
+        onSearchResults={handleSearchResults}
+        showAdvancedFilters={true}
+        showSortOptions={true}
+        showSearchHistory={true}
+        initialMode="advanced"
+        placeholder="Search cards... (try: name:fire, cost:>=3, type:familiar)"
+      />
+      
+      {/* Search Results Display */}
+      {searchResults.totalCount > 0 && (
+        <div style={{ marginTop: '30px' }}>
+          <div style={{ 
+            display: 'flex', 
+            justifyContent: 'space-between', 
+            alignItems: 'center',
+            marginBottom: '20px',
+            color: '#ccc'
+          }}>
+            <span>
+              Found {searchResults.totalCount} cards 
+              {searchResults.searchTime > 0 && ` in ${searchResults.searchTime}ms`}
+            </span>
+          </div>
+          
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+            gap: '20px'
+          }}>
+            {searchResults.cards.map(card => (
+              <div
+                key={card.id}
+                style={{
+                  background: 'rgba(255, 255, 255, 0.05)',
+                  border: '1px solid rgba(212, 175, 55, 0.3)',
+                  borderRadius: '8px',
+                  padding: '15px',
+                  transition: 'all 0.3s ease'
+                }}
+              >
+                <h3 style={{ color: '#d4af37', marginBottom: '10px' }}>
+                  {card.name}
+                </h3>
+                <div style={{ marginBottom: '8px' }}>
+                  <span style={{ color: '#ccc' }}>Type: </span>
+                  <span style={{ color: '#fff' }}>{card.type}</span>
+                  <span style={{ color: '#ccc', marginLeft: '15px' }}>Cost: </span>
+                  <span style={{ color: '#fff' }}>{card.cost}</span>
+                </div>
+                {card.strength && (
+                  <div style={{ marginBottom: '8px' }}>
+                    <span style={{ color: '#ccc' }}>Strength: </span>
+                    <span style={{ color: '#fff' }}>{card.strength}</span>
+                  </div>
+                )}
+                <div style={{ marginBottom: '8px' }}>
+                  <span style={{ color: '#ccc' }}>Rarity: </span>
+                  <span style={{ 
+                    color: card.rarity === 'Rare' ? '#FFD700' : 
+                          card.rarity === 'Uncommon' ? '#C0C0C0' : '#CD7F32'
+                  }}>
+                    {card.rarity}
+                  </span>
+                </div>
+                {card.elements.length > 0 && (
+                  <div style={{ marginBottom: '8px' }}>
+                    <span style={{ color: '#ccc' }}>Elements: </span>
+                    <span style={{ color: '#fff' }}>{card.elements.join(', ')}</span>
+                  </div>
+                )}
+                <p style={{ 
+                  color: '#ddd', 
+                  fontSize: '14px', 
+                  lineHeight: '1.4',
+                  marginBottom: '8px'
+                }}>
+                  {card.description}
+                </p>
+                {card.keywords.length > 0 && (
+                  <div style={{ marginBottom: '8px' }}>
+                    <span style={{ color: '#ccc' }}>Keywords: </span>
+                    <span style={{ color: '#d4af37' }}>{card.keywords.join(', ')}</span>
+                  </div>
+                )}
+                {card.artist && (
+                  <div style={{ fontSize: '12px', color: '#999', fontStyle: 'italic' }}>
+                    Art by {card.artist}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      
+      {/* Search Warnings */}
+      {searchResults.warnings && searchResults.warnings.length > 0 && (
+        <div style={{ 
+          marginTop: '20px', 
+          padding: '10px', 
+          background: 'rgba(255, 165, 0, 0.1)',
+          border: '1px solid rgba(255, 165, 0, 0.3)',
+          borderRadius: '4px',
+          color: '#FFA500'
+        }}>
+          {searchResults.warnings.map((warning, index) => (
+            <div key={index}>{warning}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MergedCardsPage;

--- a/src/core/Phase3App.tsx
+++ b/src/core/Phase3App.tsx
@@ -9,7 +9,7 @@ import { withAdvancedHealing } from '../utils/realTimeHealing';
 import { healingConfigManager } from '../config/healingConfig';
 import BlogSection from '../components/BlogSection';
 import UnifiedCardSearch from '../components/UnifiedCardSearch';
-import SearchPage from '../components/SearchPage';
+import MergedCardsPage from '../components/MergedCardsPage';
 import EnhancedLoginModal from '../components/EnhancedLoginModal';
 import AccessibilityButton from '../components/AccessibilityButton';
 import SkipToContent from '../components/SkipToContent';
@@ -343,7 +343,6 @@ const Header = () => {
   
   const navLinks: NavLink[] = [
     { to: '/cards', label: 'Cards' },
-    { to: '/search', label: 'Search' },
     { to: '/decks', label: 'Decks' },
     { to: '/events', label: 'Events' },
     { to: '/play', label: 'Play', special: true },
@@ -1134,8 +1133,7 @@ const Phase3App = () => {
               <AnimatePresence mode="wait">
                 <Routes>
                   <Route path="/" element={<HomePage />} />
-                  <Route path="/cards" element={<CardsPage />} />
-                  <Route path="/search" element={<SearchPage />} />
+                  <Route path="/cards" element={<MergedCardsPage />} />
                   <Route path="/decks" element={<DecksPage />} />
                   <Route path="/events" element={<EventsPage />} />
                   <Route path="/play" element={<PlayPage />} />


### PR DESCRIPTION
## Description
This PR merges the Cards and Search pages into a single unified page and removes the Search link from the header navigation.

## Changes Made
- Created a new `MergedCardsPage` component that combines functionality from both the Cards and Search pages
- Removed the Search link from the header navigation
- Updated the routes to use the new merged component
- Removed the separate route for the Search page

## Justification
Merging these pages simplifies the user experience by providing a single location for browsing and searching cards. This reduces navigation complexity and makes the application more intuitive to use.

## Impact
- Users will now find all card-related functionality in one place
- The header navigation is cleaner with fewer options
- The application maintains all existing functionality but with improved organization

## Testing
- Verified that the new merged page displays correctly
- Confirmed that card search functionality works as expected
- Ensured that the header navigation displays correctly without the Search link

@MichaelWBrennan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/be1b2b10ac904ac0ae9d5d9b7e2e7c54)