### PR TITLE
Fix syntax error in MergedCardsPage.tsx

### DIFF
--- a/src/components/MergedCardsPage.tsx
+++ b/src/components/MergedCardsPage.tsx
@@ -235,8 +235,6 @@ const MergedCardsPage: React.FC = () => {
           ))}
         </div>
       )}
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR fixes a syntax error in the MergedCardsPage.tsx file that was causing the build to fail. The issue was an extra closing `</div>` tag and an extra closing parenthesis `)}` that were causing a syntax error during the build process.

The error was:
```
[vite:esbuild] Transform failed with 1 error:
/vercel/path0/src/components/MergedCardsPage.tsx:240:5: ERROR: Expected identifier but found "/"
```

This fix removes the extra closing tags to ensure proper syntax.

@MichaelWBrennan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/509e50dba7704552890b2b5c0a80e11a)