### PR TITLE
Add functionality to 'Play as Guest' button

### DIFF
--- a/src/core/Phase3App.tsx
+++ b/src/core/Phase3App.tsx
@@ -859,7 +859,19 @@ const PlayPage = () => {
               Create Account
             </motion.button>
             <motion.button
-              onClick={() => setShowLoginModal(false)}
+              onClick={() => {
+                // Create a guest user with a random ID
+                const guestUser: User = {
+                  id: `guest_${Date.now()}`,
+                  username: `Guest_${Math.floor(Math.random() * 10000)}`,
+                  email: '',
+                  level: 1
+                };
+                // Set the user in context
+                setUser(guestUser);
+                // Close the login modal
+                setShowLoginModal(false);
+              }}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
               style={{


### PR DESCRIPTION
This PR adds proper functionality to the "Play as Guest" button in the login modal.

## Changes:
- Added functionality to create a guest user account when the "Play as Guest" button is clicked
- The guest user is assigned a random ID and username (e.g., Guest_1234)
- The guest user is set in the application context, allowing users to access the application without creating an account
- The login modal is closed after the guest user is created

## Why this change:
Previously, the "Play as Guest" button only closed the login modal without actually creating a guest session, which meant users couldn't properly access the application features. This change:
1. Provides a true guest experience without requiring account creation
2. Improves user experience by making the button work as expected
3. Allows new users to try the application before committing to creating an account

## Testing:
- Verified that clicking the "Play as Guest" button creates a guest user with a random ID and username
- Confirmed that the login modal closes after clicking the button
- Tested that the application recognizes the guest user and allows access to features

@MichaelWBrennan can click here to [continue refining the PR](https://app.all-hands.dev/conversations/509e50dba7704552890b2b5c0a80e11a)