### PR TITLE
Remove OpenDyslexic and dark buttons as they are defaults

### DIFF
--- a/src/components/AccessibilityPanel.tsx
+++ b/src/components/AccessibilityPanel.tsx
@@ -4,9 +4,9 @@ import { applyFontFamily, logFontStatus, waitForFontsToLoad } from '../utils/fon
 
 // Define accessibility settings interface
 export interface AccessibilitySettings {
-  fontFamily: 'default' | 'opendyslexic' | 'arial' | 'comic-sans';
+  fontFamily: 'default' | 'arial' | 'comic-sans';
   fontSize: 'small' | 'medium' | 'large' | 'x-large';
-  contrast: 'default' | 'high-contrast' | 'dark' | 'light';
+  contrast: 'default' | 'high-contrast' | 'light';
   animations: 'default' | 'reduced' | 'none';
   lineSpacing: 'default' | 'increased' | 'double';
   letterSpacing: 'default' | 'increased' | 'wide';
@@ -96,11 +96,6 @@ const AccessibilityPanel: React.FC<AccessibilityPanelProps> = ({ isOpen, onClose
         bgColor = '#000000';
         textColor = '#ffffff';
         accentColor = '#ffff00';
-        break;
-      case 'dark':
-        bgColor = '#121212';
-        textColor = '#ffffff';
-        accentColor = '#d4af37';
         break;
       case 'light':
         bgColor = '#ffffff';
@@ -312,7 +307,6 @@ const AccessibilityPanel: React.FC<AccessibilityPanelProps> = ({ isOpen, onClose
                       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
                         {[
                           { id: 'default', label: 'Default' },
-                          { id: 'opendyslexic', label: 'OpenDyslexic' },
                           { id: 'arial', label: 'Arial' },
                           { id: 'comic-sans', label: 'Comic Sans' }
                         ].map(font => (
@@ -327,8 +321,7 @@ const AccessibilityPanel: React.FC<AccessibilityPanelProps> = ({ isOpen, onClose
                               background: settings.fontFamily === font.id ? 'rgba(212, 175, 55, 0.2)' : 'transparent',
                               color: 'var(--text-color, white)',
                               cursor: 'pointer',
-                              fontFamily: font.id === 'opendyslexic' ? 'OpenDyslexic, sans-serif' : 
-                                         font.id === 'arial' ? 'Arial, sans-serif' : 
+                              fontFamily: font.id === 'arial' ? 'Arial, sans-serif' : 
                                          font.id === 'comic-sans' ? '"Comic Sans MS", cursive' : 'inherit'
                             }}
                           >
@@ -446,7 +439,6 @@ const AccessibilityPanel: React.FC<AccessibilityPanelProps> = ({ isOpen, onClose
                         {[
                           { id: 'default', label: 'Default' },
                           { id: 'high-contrast', label: 'High Contrast' },
-                          { id: 'dark', label: 'Dark' },
                           { id: 'light', label: 'Light' }
                         ].map(contrast => (
                           <button

--- a/src/hooks/useAccessibilitySettings.ts
+++ b/src/hooks/useAccessibilitySettings.ts
@@ -2,9 +2,9 @@ import { useEffect } from 'react';
 import { applyFontFamily, logFontStatus, waitForFontsToLoad } from '../utils/fontUtils';
 
 export interface AccessibilitySettings {
-  fontFamily: 'default' | 'opendyslexic' | 'arial' | 'comic-sans';
+  fontFamily: 'default' | 'arial' | 'comic-sans';
   fontSize: 'small' | 'medium' | 'large' | 'x-large';
-  contrast: 'default' | 'high-contrast' | 'dark' | 'light';
+  contrast: 'default' | 'high-contrast' | 'light';
   animations: 'default' | 'reduced' | 'none';
   lineSpacing: 'default' | 'increased' | 'double';
   letterSpacing: 'default' | 'increased' | 'wide';
@@ -74,11 +74,6 @@ export const useAccessibilitySettings = () => {
           bgColor = '#000000';
           textColor = '#ffffff';
           accentColor = '#ffff00';
-          break;
-        case 'dark':
-          bgColor = '#121212';
-          textColor = '#ffffff';
-          accentColor = '#d4af37';
           break;
         case 'light':
           bgColor = '#ffffff';

--- a/src/utils/fontUtils.ts
+++ b/src/utils/fontUtils.ts
@@ -108,9 +108,6 @@ export function applyFontFamily(fontType: string): string {
   let fontFamily = '';
   
   switch (fontType) {
-    case 'opendyslexic':
-      fontFamily = '"OpenDyslexic", "Comic Sans MS", "Chalkboard SE", cursive, sans-serif';
-      break;
     case 'arial':
       fontFamily = 'Arial, "Helvetica Neue", Helvetica, sans-serif';
       break;


### PR DESCRIPTION
- Removed OpenDyslexic font button since it's included in the default font stack
- Removed dark contrast button since default theme is already dark
- Updated TypeScript interfaces to reflect removed options
- Simplified font and contrast selection UI
- Updated font utility and accessibility settings logic

The default font family already includes OpenDyslexic as the primary font, and the default contrast is already dark-themed, making these buttons redundant.