### PR TITLE
feat(ocr): Add card data extraction from images

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -38,6 +38,7 @@
         "redis": "^4.6.7",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
+        "scribe.js-ocr": "^0.8.0",
         "socket.io": "^4.7.2",
         "typeorm": "^0.3.17",
         "uuid": "^9.0.0"
@@ -275,24 +276,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -321,22 +304,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/rxjs": {
@@ -3669,6 +3636,30 @@
         "@redis/client": "^1.0.0"
       }
     },
+    "node_modules/@scribe.js/tesseract.js": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@scribe.js/tesseract.js/-/tesseract.js-6.0.2.tgz",
+      "integrity": "sha512-FaLrLXtgpnQDI2fZSwg6plAgMm6s24v3rxTiG9zObKI22wPAH98CUVNR7BqgEVu3Yq7jLVWyoq14C4iJbWQcZA==",
+      "hasInstallScript": true,
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@scribe.js/tesseract.js-core": "^6.0.3",
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/@scribe.js/tesseract.js-core": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@scribe.js/tesseract.js-core/-/tesseract.js-core-6.0.3.tgz",
+      "integrity": "sha512-q2bXN0yQCEs5IA9138vF+xGSfNhOaMVdPKkuZNSiz3A+SfuRZuAU3iKzIXJMdSJnWvHSBOUPLDdqguClCNX9Qw==",
+      "license": "AGPL-3.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -4555,6 +4546,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5088,21 +5085,6 @@
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5114,6 +5096,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -5376,6 +5364,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.39.1.tgz",
+      "integrity": "sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5424,33 +5421,6 @@
       "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -7657,6 +7627,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -7791,21 +7767,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -7944,6 +7905,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -9579,6 +9546,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10302,36 +10278,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/redis": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
@@ -10375,6 +10321,12 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -10682,6 +10634,29 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/scribe.js-ocr": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/scribe.js-ocr/-/scribe.js-ocr-0.8.0.tgz",
+      "integrity": "sha512-ADEU2gydKCMS2paI/g1ronhUkGHLb3UzWFaLOK12S+++WesgTEr8l/LQYPOxkt1LMhtbC6B2FGZfkBqAQXSxLw==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@scribe.js/tesseract.js": "^6.0.2",
+        "canvaskit-wasm": "^0.39.1",
+        "commander": "^11.1.0"
+      },
+      "bin": {
+        "scribe": "cli/scribe.js"
+      }
+    },
+    "node_modules/scribe.js-ocr/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/secure-json-parse": {
       "version": "3.0.2",
@@ -12390,6 +12365,12 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -12808,6 +12789,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,7 +53,8 @@
     "rxjs": "^7.8.1",
     "socket.io": "^4.7.2",
     "typeorm": "^0.3.17",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "scribe.js-ocr": "^0.8.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.10",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { RatingsModule } from './ratings/ratings.module';
 import { AuditModule } from './audit/audit.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+import { OcrModule } from './ocr/ocr.module';
 
 @Module({
   imports: [
@@ -100,6 +101,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
     PhysicalSimulationModule,
     NotificationsModule,
     AnalyticsModule,
+    OcrModule,
   ],
   controllers: [],
   providers: [

--- a/backend/src/cards/dto/card.dto.ts
+++ b/backend/src/cards/dto/card.dto.ts
@@ -69,6 +69,10 @@ export class CreateCardDto {
   @IsOptional()
   @IsBoolean()
   isLegal?: boolean;
+
+  @ApiProperty({ description: 'Additional metadata as JSON', required: false })
+  @IsOptional()
+  metadata?: Record<string, any>;
 }
 
 export class UpdateCardDto {

--- a/backend/src/ocr/ocr.controller.spec.ts
+++ b/backend/src/ocr/ocr.controller.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OcrController } from './ocr.controller';
+import { OcrService } from './ocr.service';
+import { CardsService } from '../cards/cards.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Card } from '../cards/entities/card.entity';
+
+describe('OcrController', () => {
+  let controller: OcrController;
+  let service: OcrService;
+
+  const mockOcrService = {
+    extractCardData: jest.fn(),
+  };
+
+  const mockCardsService = {
+    create: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OcrController],
+      providers: [
+        {
+          provide: OcrService,
+          useValue: mockOcrService,
+        },
+        // OcrService depends on CardsService, so we need to provide a mock for it.
+        // Even though we are mocking OcrService directly, the dependency needs to be resolved.
+        {
+          provide: CardsService,
+          useValue: mockCardsService,
+        },
+        // CardsService depends on the Card repository.
+        {
+          provide: getRepositoryToken(Card),
+          useValue: {}, // empty mock for the repository
+        }
+      ],
+    }).compile();
+
+    controller = module.get<OcrController>(OcrController);
+    service = module.get<OcrService>(OcrService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('uploadFile', () => {
+    it('should call OcrService.extractCardData with the uploaded file', async () => {
+      const file: Express.Multer.File = {
+        fieldname: 'file',
+        originalname: 'test.png',
+        encoding: '7bit',
+        mimetype: 'image/png',
+        size: 12345,
+        buffer: Buffer.from('test'),
+        stream: null,
+        destination: '',
+        filename: '',
+        path: ''
+      };
+
+      const expectedResult = { message: 'success' };
+      mockOcrService.extractCardData.mockResolvedValue(expectedResult);
+
+      const result = await controller.uploadFile(file);
+
+      expect(service.extractCardData).toHaveBeenCalledWith(file);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/backend/src/ocr/ocr.controller.ts
+++ b/backend/src/ocr/ocr.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { OcrService } from './ocr.service';
+import { ApiTags, ApiOperation, ApiResponse, ApiConsumes } from '@nestjs/swagger';
+
+@ApiTags('ocr')
+@Controller('api/ocr')
+export class OcrController {
+  constructor(private readonly ocrService: OcrService) {}
+
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'Upload a card image for OCR processing' })
+  @ApiConsumes('multipart/form-data')
+  @ApiResponse({ status: 201, description: 'Card data extracted successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid file upload' })
+  async uploadFile(@UploadedFile() file: Express.Multer.File) {
+    return this.ocrService.extractCardData(file);
+  }
+}

--- a/backend/src/ocr/ocr.module.ts
+++ b/backend/src/ocr/ocr.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OcrController } from './ocr.controller';
+import { OcrService } from './ocr.service';
+import { CardsModule } from '../cards/cards.module';
+
+@Module({
+  imports: [CardsModule],
+  controllers: [OcrController],
+  providers: [OcrService],
+})
+export class OcrModule {}

--- a/backend/src/ocr/ocr.service.ts
+++ b/backend/src/ocr/ocr.service.ts
@@ -1,0 +1,122 @@
+import { Injectable, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { CardsService } from '../cards/cards.service';
+import { CreateCardDto } from '../cards/dto/card.dto';
+import { CardElement, CardRarity, CardType } from '../cards/entities/card.entity';
+
+@Injectable()
+export class OcrService {
+  constructor(private readonly cardsService: CardsService) {}
+
+  async extractCardData(file: Express.Multer.File): Promise<any> {
+    if (!file) {
+      throw new BadRequestException('No file uploaded.');
+    }
+
+    let ocrResult: string;
+    try {
+      const scribe = (await import('scribe.js-ocr')).default;
+      ocrResult = await scribe.extractText(file.buffer);
+    } catch (error) {
+      console.error('OCR processing failed:', error);
+      throw new InternalServerErrorException('OCR processing failed.');
+    }
+
+    const lines = ocrResult.split('\n').filter(line => line.trim() !== '');
+
+    if (lines.length < 3) {
+      throw new BadRequestException('Could not parse card data from image. OCR result was too short.');
+    }
+
+    const name = lines[0].trim();
+    const lesser_type = lines[1].trim();
+
+    const setAndNumberRegex = /([A-Z\d-]+[-•♀-][A-Z\d-]*)\s+(\d+\/\d+)/;
+    let set_and_rarity_symbol: string | null = null;
+    let set_number: string | null = null;
+    let flavor_text: string | null = null;
+    const abilities: string[] = [];
+
+    const setLineIndex = lines.findIndex(line => setAndNumberRegex.test(line));
+    if (setLineIndex !== -1) {
+      const match = lines[setLineIndex].match(setAndNumberRegex);
+      if (match) {
+        set_and_rarity_symbol = match[1];
+        set_number = match[2];
+      }
+    }
+
+    const flavorTextStartIndex = lines.findIndex(line => line.includes('~') || line.startsWith('“'));
+    if (flavorTextStartIndex !== -1) {
+      const endOfFlavor = setLineIndex !== -1 ? setLineIndex : lines.length;
+      flavor_text = lines.slice(flavorTextStartIndex, endOfFlavor).join('\n').trim();
+    }
+
+    const abilitiesStartIndex = 2;
+    const abilitiesEndIndex = flavorTextStartIndex !== -1 ? flavorTextStartIndex : (setLineIndex !== -1 ? setLineIndex : lines.length);
+
+    for (let i = abilitiesStartIndex; i < abilitiesEndIndex; i++) {
+      abilities.push(...lines[i].split(/, |\. /).map(s => s.trim()).filter(Boolean));
+    }
+
+    // This is a heuristic and would need to be improved for a real system
+    const element = this.mapTextToElement(abilities[0] || lesser_type);
+
+    const createCardDto: CreateCardDto = {
+      name,
+      type: this.mapTextToCardType(lesser_type),
+      element,
+      rarity: CardRarity.COMMON, // Heuristic, would need symbol recognition
+      cost: 0, // Not available on the card
+      description: abilities.join(', '),
+      flavorText: flavor_text,
+      keywords: abilities,
+      imageUrl: `uploads/${file.originalname}`,
+      metadata: {
+        set_and_rarity_symbol,
+        set_number,
+        image_path: `uploads/${file.originalname}`,
+        raw_ocr: ocrResult,
+      },
+    };
+
+    const createdCard = await this.cardsService.create(createCardDto);
+
+    // Return the JSON in the format requested by the user
+    return {
+      element: createdCard.element,
+      name: createdCard.name,
+      lesser_type: lesser_type, // Return the parsed type string
+      abilities: createdCard.keywords,
+      flavor_text: createdCard.flavorText,
+      set_and_rarity_symbol: set_and_rarity_symbol,
+      set_number: set_number,
+      image_path: `uploads/${file.originalname}`,
+    };
+  }
+
+  private mapTextToCardType(text: string): CardType {
+    const upperText = text.toUpperCase();
+    if (upperText.includes('FAMILIAR') || upperText.includes('CREATURE')) {
+      return CardType.FAMILIAR;
+    }
+    if (upperText.includes('SPELL')) {
+      return CardType.SPELL;
+    }
+    if (upperText.includes('FLAG')) {
+        return CardType.FLAG;
+    }
+    return CardType.SPELL; // Default
+  }
+
+  private mapTextToElement(text: string): CardElement {
+    const upperText = text.toUpperCase();
+    if (upperText.includes('FIRE')) return CardElement.FIRE;
+    if (upperText.includes('WATER')) return CardElement.WATER;
+    if (upperText.includes('EARTH')) return CardElement.EARTH;
+    if (upperText.includes('AIR')) return CardElement.AIR;
+    if (upperText.includes('AETHER')) return CardElement.AETHER;
+    if (upperText.includes('NETHER')) return CardElement.NETHER;
+    if (upperText.includes('VOID')) return CardElement.NETHER; // Mapping 'VOID' to 'NETHER' as per example
+    return CardElement.GENERIC;
+  }
+}


### PR DESCRIPTION
This commit introduces a new feature to extract card data from an uploaded image using OCR.

- Adds a new `OcrModule` to the backend, with a controller and service.
- The `OcrController` provides a new endpoint `/api/ocr/upload` for image uploads.
- The `OcrService` uses the `scribe.js-ocr` library to perform OCR on the uploaded image.
- Implements logic to parse the extracted text and map it to the card data structure.
- Integrates with the existing `CardsService` to create a new card entry in the database.
- The endpoint returns a JSON object with the extracted card details as specified.
- Adds a unit test for the new `OcrController` to ensure it's correctly wired.
- Updates the `CreateCardDto` to include a `metadata` field for storing additional OCR data.