### PR TITLE
Rearrange menu links and deck features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { KonivrverSimulator } from "./components/KonivrverSimulator";
 import JudgePortal from "./components/JudgePortal";
 import NotificationCenter from "./components/NotificationCenter";
 import { DeckBuilderAdvanced } from "./pages/DeckBuilderAdvanced";
+import { Profile } from "./pages/Profile";
 
 import { Analytics } from "./pages/Analytics";
 import { Events } from "./pages/Events";
@@ -57,6 +58,7 @@ type Page =
   | "rules"
   | "judge"
   | "settings"
+  | "profile"
   | "lore";
 
 function AppContent(): any {
@@ -130,7 +132,8 @@ function AppContent(): any {
       {!(
         currentPage === "settings" ||
         currentPage === "deckbuilder" ||
-        currentPage === "simulator"
+        currentPage === "simulator" ||
+        currentPage === "profile"
       ) && <SearchBar current={currentPage} onSearch={handleGlobalSearch} />}
 
       <MobileShell
@@ -172,6 +175,7 @@ function AppContent(): any {
         {currentPage === "events" && <Events />}
         {currentPage === "event-archive" && <TournamentHub />}
         {currentPage === "deckbuilder" && <DeckBuilderAdvanced />}
+        {currentPage === "profile" && <Profile />}
         {currentPage === "analytics" && <Analytics />}
         {currentPage === "settings" && <Settings />}
       </MobileShell>

--- a/src/components/BubbleMenu.tsx
+++ b/src/components/BubbleMenu.tsx
@@ -132,13 +132,13 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = ({
     ...(isAuthenticated
       ? [{ id: "my-decks" as const, label: "My Decks" }]
       : []),
-    { id: "simulator" as const, label: "Simulator" },
+    { id: "events" as const, label: "Events" },
     { id: "rules" as const, label: "Rules" },
     // Only show Judge Portal to authenticated judges and admins
     ...(canAccessJudgePortal()
       ? [{ id: "judge" as const, label: "Judge Portal" }]
       : []),
-    { id: "events" as const, label: "Events" },
+    { id: "simulator" as const, label: "Play" },
     // Combined tournaments and companion functionality into unified Events
   ];
 

--- a/src/components/DeckSearch.tsx
+++ b/src/components/DeckSearch.tsx
@@ -2,12 +2,14 @@ import React, { useState, useMemo } from "react";
 import * as nav from "../nav.css.ts";
 import * as ds from "./deckSearch.css.ts";
 import { Deck, cardDatabase } from "../data/cards";
+import { DeckBuilderAdvanced } from "../pages/DeckBuilderAdvanced";
 
 interface DeckSearchProps {
   onDeckSelect?: (deck: Deck) => void;
 }
 
 export const DeckSearch: React.FC<DeckSearchProps> = ({ onDeckSelect }) => {
+  const [activeTab, setActiveTab] = useState<"search" | "builder">("search");
   const [searchTerm, setSearchTerm] = useState("");
   const [elementFilter, setElementFilter] = useState("");
   // Removed format filter dropdown and logic
@@ -60,112 +62,136 @@ export const DeckSearch: React.FC<DeckSearchProps> = ({ onDeckSelect }) => {
   return (
     <div>
       <div className="search-container">
-        <h1 className={nav.navTitle}>Deck Search</h1>
-        <input
-          type="text"
-          placeholder="Search decks by name or description..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          className="search-input"
-        />
-
-        <div className="filters">
-          <select
-            value={elementFilter}
-            onChange={(e) => setElementFilter(e.target.value)}
-            className="filter-select"
+        <div className="view-tabs">
+          <button
+            className={`btn ${activeTab === "search" ? "btn-primary" : "btn-secondary"}`}
+            onClick={() => setActiveTab("search")}
           >
-            <option value="">All Elements</option>
-            {elements.map((element) => (
-              <option key={element} value={element}>
-                {element}
-              </option>
-            ))}
-          </select>
-
-          {/* Removed format filter dropdown */}
+            Search
+          </button>
+          <button
+            className={`btn ${activeTab === "builder" ? "btn-primary" : "btn-secondary"}`}
+            onClick={() => setActiveTab("builder")}
+          >
+            Deck Builder
+          </button>
         </div>
+        <h1 className={nav.navTitle}>Decks</h1>
+        {activeTab === "search" && (
+          <input
+            type="text"
+            placeholder="Search decks by name or description..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="search-input"
+          />
+        )}
 
-        <div className="results-count">{filteredDecks.length} decks found</div>
+        {activeTab === "search" && (
+          <div className="filters">
+            <select
+              value={elementFilter}
+              onChange={(e) => setElementFilter(e.target.value)}
+              className="filter-select"
+            >
+              <option value="">All Elements</option>
+              {elements.map((element) => (
+                <option key={element} value={element}>
+                  {element}
+                </option>
+              ))}
+            </select>
+
+            {/* Removed format filter dropdown */}
+          </div>
+        )}
+
+        {activeTab === "search" && (
+          <div className="results-count">{filteredDecks.length} decks found</div>
+        )}
       </div>
 
-      <div className="card-grid">
-        {filteredDecks.map((deck) => {
-          const previewCards = getDeckPreviewCards(deck);
+      {activeTab === "search" ? (
+        <div className="card-grid">
+          {filteredDecks.map((deck) => {
+            const previewCards = getDeckPreviewCards(deck);
 
-          return (
-            <div key={deck.id} className={`card-item ${ds.cardItem}`}>
-              <div className={ds.previewRow}>
-                {previewCards.map((card, index) => (
-                  <img
-                    key={card?.id}
-                    src={card?.webpUrl}
-                    alt={card?.name}
-                    style={{
-                      width: `${100 / previewCards.length}%`,
-                      height: "100%",
-                      objectFit: "cover",
-                      opacity: 1 - index * 0.1,
-                    }}
-                    className={ds.previewImg}
-                    onError={(e) => {
-                      // Fallback to PNG if WebP fails
-                      if (card) {
-                        (e.target as HTMLImageElement).src = card.imageUrl;
-                      }
-                    }}
-                  />
-                ))}
-              </div>
-              <div className="card-info">
-                <div className="card-name">{deck.name}</div>
-                <div className="card-details">
-                  <div>
-                    {deck.mainElement} • {deck.format}
-                  </div>
-                  <div>
-                    {deck.cards.length} cards • Win Rate:{" "}
-                    {(deck.winRate * 100).toFixed(0)}%
-                  </div>
-                  <div className={ds.desc}>{deck.description}</div>
-                  <div className={ds.meta}>
-                    Updated: {deck.updatedAt.toLocaleDateString()}
-                  </div>
-                  <div className={ds.actions}>
-                    <button
-                      className={`btn btn-primary ${ds.actionBtn}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleAddToMyAccount(deck);
+            return (
+              <div key={deck.id} className={`card-item ${ds.cardItem}`}>
+                <div className={ds.previewRow}>
+                  {previewCards.map((card, index) => (
+                    <img
+                      key={card?.id}
+                      src={card?.webpUrl}
+                      alt={card?.name}
+                      style={{
+                        width: `${100 / previewCards.length}%`,
+                        height: "100%",
+                        objectFit: "cover",
+                        opacity: 1 - index * 0.1,
                       }}
-                    >
-                      + My Account
-                    </button>
-                    <button
-                      className={`btn btn-secondary ${ds.actionBtn}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handlePlayInSimulator(deck);
+                      className={ds.previewImg}
+                      onError={(e) => {
+                        // Fallback to PNG if WebP fails
+                        if (card) {
+                          (e.target as HTMLImageElement).src = card.imageUrl;
+                        }
                       }}
-                    >
-                      🎮 Play
-                    </button>
-                    <button
-                      className="btn"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDeckSelect?.(deck);
-                      }}
-                    >
-                      View
-                    </button>
+                    />
+                  ))}
+                </div>
+                <div className="card-info">
+                  <div className="card-name">{deck.name}</div>
+                  <div className="card-details">
+                    <div>
+                      {deck.mainElement} • {deck.format}
+                    </div>
+                    <div>
+                      {deck.cards.length} cards • Win Rate: {""}
+                      {(deck.winRate * 100).toFixed(0)}%
+                    </div>
+                    <div className={ds.desc}>{deck.description}</div>
+                    <div className={ds.meta}>
+                      Updated: {deck.updatedAt.toLocaleDateString()}
+                    </div>
+                    <div className={ds.actions}>
+                      <button
+                        className={`btn btn-primary ${ds.actionBtn}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleAddToMyAccount(deck);
+                        }}
+                      >
+                        + My Account
+                      </button>
+                      <button
+                        className={`btn btn-secondary ${ds.actionBtn}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handlePlayInSimulator(deck);
+                        }}
+                      >
+                        🎮 Play
+                      </button>
+                      <button
+                        className="btn"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDeckSelect?.(deck);
+                        }}
+                      >
+                        View
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      ) : (
+        <DeckBuilderAdvanced />
+      )}
     </div>
   );
 };

--- a/src/mobile/MobileNav.tsx
+++ b/src/mobile/MobileNav.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import * as s from "./mobileNav.css.ts";
 import { useAuth } from "../hooks/useAuth";
 
-type Tab = "home" | "cards" | "decks" | "simulator" | "more";
+type Tab = "home" | "cards" | "decks" | "events" | "more";
 
 interface Props {
   current: string;
@@ -38,20 +38,24 @@ export const MobileNav: React.FC<Props> = ({ current, onNavigate }) => {
           <span className={s.label}>Decks</span>
         </button>
         <button
-          className={`${s.tab} ${active("simulator")}`}
-          aria-current={current === "simulator"}
-          onClick={() => onNavigate("simulator")}
+          className={`${s.tab} ${active("events")}`}
+          aria-current={current === "events"}
+          onClick={() => onNavigate("events")}
         >
-          <span className={s.label}>Play</span>
+          <span className={s.label}>Events</span>
         </button>
         <button
           className={`${s.tab}`}
           onClick={() => {
-            const evt = new CustomEvent("open-login");
-            window.dispatchEvent(evt);
+            if (isAuthenticated) {
+              onNavigate("profile");
+            } else {
+              const evt = new CustomEvent("open-login");
+              window.dispatchEvent(evt);
+            }
           }}
         >
-          <span className={s.label}>Login</span>
+          <span className={s.label}>{isAuthenticated ? "Profile" : "Login"}</span>
         </button>
         <button
           className={`${s.tab} ${active("more")}`}
@@ -77,8 +81,7 @@ export const MobileNav: React.FC<Props> = ({ current, onNavigate }) => {
             {(
               [
                 ...(isAuthenticated ? [["my-decks", "My Decks"] as const] : []),
-                ["deckbuilder", "Deckbuilder"] as const,
-                ["events", "Events"] as const,
+                ["simulator", "Play"] as const,
                 ["rules", "Rules"] as const,
                 ["lore", "Lore"] as const,
                 ...(canAccessJudgePortal()

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import * as s from "./settings.css.ts";
+import { useAuth } from "../hooks/useAuth";
+import { TournamentSection } from "../components/TournamentSection";
+import { QualificationTracker } from "../components/QualificationTracker";
+import { ProgressionService, TournamentProfileDto } from "../services/progressionService";
+
+export const Profile: React.FC = () => {
+  const { user, isAuthenticated } = useAuth();
+  const [profile, setProfile] = useState<TournamentProfileDto | null>(null);
+
+  useEffect(() => {
+    if (isAuthenticated && user?.id) {
+      ProgressionService.getProfile(user.id).then(setProfile).catch(() => setProfile(null));
+    }
+  }, [isAuthenticated, user?.id]);
+
+  if (!isAuthenticated) {
+    return (
+      <div className={s.root}>
+        <section className={s.section}>
+          <div className={s.sectionTitle}>Profile</div>
+          <p>Please log in to view your profile.</p>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className={s.root}>
+      <section className={s.section}>
+        <div className={s.sectionTitle}>Profile</div>
+        <div className="small text-muted">{user?.displayName || user?.username}</div>
+      </section>
+
+      <section className={s.section}>
+        <div className={s.sectionTitle}>Tournament Points</div>
+        <TournamentSection userId={user?.id || ""} />
+        <QualificationTracker currentPoints={profile?.currentPoints || 0} />
+      </section>
+    </div>
+  );
+};
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import * as s from "./settings.css.ts";
-import { TournamentSection } from "../components/TournamentSection";
-import { QualificationTracker } from "../components/QualificationTracker";
+// Tournament points moved to Profile page
 
 export const Settings: React.FC = () => {
   const [theme, setTheme] = useState<"dark" | "light">(
@@ -39,11 +38,6 @@ export const Settings: React.FC = () => {
 
   return (
     <div className={s.root}>
-      <section className={s.section}>
-        <div className={s.sectionTitle}>Tournaments</div>
-        <TournamentSection userId={localStorage.getItem("userId") || ""} />
-        <QualificationTracker currentPoints={0} />
-      </section>
       <section className={s.section}>
         <div className={s.sectionTitle}>Appearance</div>
         <div className={s.row}>


### PR DESCRIPTION
Swapped "Events" and "Play" in navigation, merged "Deck Builder" into "Deck Search" as a tab, and moved "Tournament Points" to a new "Profile" page to improve UI organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-72223a71-76c6-44c1-a249-39d77c3e1cb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72223a71-76c6-44c1-a249-39d77c3e1cb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

