### PR TITLE
Style the more button to match others

### DIFF
--- a/src/mobile/mobileNav.css.ts
+++ b/src/mobile/mobileNav.css.ts
@@ -31,13 +31,11 @@ export const tab = style({
   flexDirection: "column",
   alignItems: "center",
   justifyContent: "center",
-  color: "var(--text-secondary)",
+  color: "#000",
   cursor: "pointer",
+  borderRight: "1px solid var(--border-color)",
   selectors: {
     "&:active": { opacity: 0.8 },
-    "&:not(:last-child)": {
-      borderRight: "1px solid var(--border-color)",
-    },
     "&:hover": {
       background: "rgba(0,0,0,0.08)",
     },
@@ -45,7 +43,7 @@ export const tab = style({
 });
 
 export const tabActive = style({
-  color: "var(--text-primary)",
+  color: "#000",
   background: "rgba(0,0,0,0.12)",
 });
 


### PR DESCRIPTION
Align "More" button styling with other mobile navigation tabs and set all tab text colors to black.

---
<a href="https://cursor.com/background-agent?bcId=bc-c133676e-6509-48cb-ae0c-d09d70ce7467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c133676e-6509-48cb-ae0c-d09d70ce7467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

