### PR TITLE
Invert button colors on click

### DIFF
--- a/src/global.css.ts
+++ b/src/global.css.ts
@@ -406,6 +406,8 @@ globalStyle(".btn-secondary", {
 
 // Pressed/clicked state
 globalStyle(".btn:active", { background: "#000", color: "#fff" });
+globalStyle(".btn-primary:active", { background: "#fff", color: "#000", border: "1px solid #000" });
+globalStyle(".btn-secondary:active", { background: "#000", color: "#fff" });
 
 // Generic tab buttons used in some pages
 globalStyle(".tab", {
@@ -418,6 +420,7 @@ globalStyle(".tab", {
   transition: "all 0.2s ease",
 });
 globalStyle(".tab.active", { background: "#000", color: "#fff" });
+globalStyle(".tab:not(.active)", { background: "#fff", color: "#000" });
 
 globalStyle(".btn-danger", { background: "#ef4444", color: "#fff" });
 

--- a/src/pages/CompanionPage.tsx
+++ b/src/pages/CompanionPage.tsx
@@ -212,6 +212,11 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
             transform: translateY(-2px);
             background: #111;
           }
+          .btn-primary:active {
+            background: #fff;
+            color: #000;
+            border: 1px solid #000;
+          }
           
           .btn-secondary {
             background: #fff;
@@ -222,6 +227,10 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
           .btn-secondary:hover {
             background: #f3f3f3;
             transform: translateY(-1px);
+          }
+          .btn-secondary:active {
+            background: #000;
+            color: #fff;
           }
           
           .companion-features {


### PR DESCRIPTION
Invert colors for clicked buttons and active/inactive tabs to improve visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-83fbfbd6-10b2-4302-b0c5-be8b71f10217">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83fbfbd6-10b2-4302-b0c5-be8b71f10217">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

