### PR TITLE
Replace plus with + in combinations

### DIFF
--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -499,7 +499,7 @@ export const Lore: React.FC = () => {
               const key = pairKey(names[0], names[1]);
               const special = specialPairs[key];
               const ideology = special ? special.title : "Synthesis";
-              const header = `${names.join(" plus ")}: ${ideology};`;
+              const header = `${names.join(" + ")}: ${ideology};`;
               const description = buildContributionExplanation(combo);
               return (
                 <p key={idx} className={s.virtueText}>
@@ -518,7 +518,7 @@ export const Lore: React.FC = () => {
               const key = comboKey(names);
               const special = specialTriples[key];
               const ideology = special ? special.title : "Synthesis";
-              const header = `${names.join(" plus ")}: ${ideology};`;
+              const header = `${names.join(" + ")}: ${ideology};`;
               const description = buildContributionExplanation(combo);
               return (
                 <p key={idx} className={s.virtueText}>
@@ -537,7 +537,7 @@ export const Lore: React.FC = () => {
               const key = comboKey(names);
               const special = specialQuads[key];
               const ideology = special ? special.title : "Synthesis";
-              const header = `${names.join(" plus ")}: ${ideology};`;
+              const header = `${names.join(" + ")}: ${ideology};`;
               const description = buildContributionExplanation(combo);
               return (
                 <p key={idx} className={s.virtueText}>
@@ -556,7 +556,7 @@ export const Lore: React.FC = () => {
               const key = comboKey(names);
               const special = specialQuints[key];
               const ideology = special ? special.title : "Synthesis";
-              const header = `${names.join(" plus ")}: ${ideology};`;
+              const header = `${names.join(" + ")}: ${ideology};`;
               const description = buildContributionExplanation(combo);
               return (
                 <p key={idx} className={s.virtueText}>


### PR DESCRIPTION
Update element combination headers to use '+' instead of 'plus' for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1d4a024-12d7-4163-8329-0340f96eceea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1d4a024-12d7-4163-8329-0340f96eceea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

