### PR TITLE
Build project with typescript errors

### DIFF
--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,7 +1,7 @@
 /**
  * Debounce function to limit how often a function can be called
  */
-export function debounce<T extends (...args: any[] = []) => any>(
+export function debounce<T extends (...args: any[]) => any>(
   func: T,
   delay: number
 ): (...args: Parameters<T>) => void {
@@ -16,7 +16,7 @@ export function debounce<T extends (...args: any[] = []) => any>(
 /**
  * Throttle function to limit how often a function can be called
  */
-export function throttle<T extends (...args: any[] = []) => any>(
+export function throttle<T extends (...args: any[]) => any>(
   func: T,
   delay: number
 ): (...args: Parameters<T>) => void {


### PR DESCRIPTION
Remove invalid parameter initializers from `debounce` and `throttle` generics to fix TypeScript build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdf0bdbd-cee9-439c-bb4d-857b8ce44df3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bdf0bdbd-cee9-439c-bb4d-857b8ce44df3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

