### PR TITLE
Fix typescript build errors

### DIFF
--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -383,8 +383,8 @@ export const Lore: React.FC = () => {
     return h % modulo;
   }
 
-  function getFactionForCombo(names: ElementDefinition["name"]): FactionEntry {
-    const key = comboKey(names as string[]);
+  function getFactionForCombo(names: ElementDefinition["name"][]): FactionEntry {
+    const key = comboKey(names);
     const size = names.length;
     if (size === 2)
       return twoColorFactions[hashKeyToIndex(key, twoColorFactions.length)];

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,7 +1,7 @@
 /**
  * Debounce function to limit how often a function can be called
  */
-export function debounce<T extends (...args: any[] = []) => any>(
+export function debounce<T extends (...args: any[]) => any>(
   func: T,
   delay: number
 ): (...args: Parameters<T>) => void {
@@ -16,7 +16,7 @@ export function debounce<T extends (...args: any[] = []) => any>(
 /**
  * Throttle function to limit how often a function can be called
  */
-export function throttle<T extends (...args: any[] = []) => any>(
+export function throttle<T extends (...args: any[]) => any>(
   func: T,
   delay: number
 ): (...args: Parameters<T>) => void {


### PR DESCRIPTION
Fix TypeScript build errors by correcting generic function signatures in `timing.ts` and array type handling in `Lore.tsx`.

The build was failing due to several TypeScript errors. In `src/utils/timing.ts`, `debounce` and `throttle` had invalid default parameter initializers within their generic type constraints. In `src/pages/Lore.tsx`, the `getFactionForCombo` function was incorrectly typed to accept a single element name but was being called with an array, leading to type mismatches and unsafe casts. These changes resolve those specific type errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-d95d860b-8b1e-4ae1-bb8c-89283369e63a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d95d860b-8b1e-4ae1-bb8c-89283369e63a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

