### PR TITLE
Fix build errors and audit dependencies

### DIFF
--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,7 +1,7 @@
 /**
  * Debounce function to limit how often a function can be called
  */
-export function debounce<T extends (...args: any[] = []) => any>(
+export function debounce<T extends (...args: any[]) => any>(
   func: T,
   delay: number,
 ): (...args: Parameters<T>) => void {
@@ -16,7 +16,7 @@ export function debounce<T extends (...args: any[] = []) => any>(
 /**
  * Throttle function to limit how often a function can be called
  */
-export function throttle<T extends (...args: any[] = []) => any>(
+export function throttle<T extends (...args: any[]) => any>(
   func: T,
   delay: number,
 ): (...args: Parameters<T>) => void {


### PR DESCRIPTION
Remove invalid default initializers from rest parameters in `debounce` and `throttle` type definitions to fix TypeScript build errors.

TypeScript errors `TS2371` and `TS1048` occurred because rest parameters in type annotations or generic constraints cannot have default initializers. Removing `= []` from `(...args: any[] = [])` resolves this syntax issue, allowing the build to complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-7981142d-1fac-4e57-a63d-45953a65f7e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7981142d-1fac-4e57-a63d-45953a65f7e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

