### PR TITLE
Fix build warnings and typescript errors

### DIFF
--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,7 +1,7 @@
 /**
  * Debounce function to limit how often a function can be called
  */
-export function debounce<T extends (...args: any[] = []) => any>(
+export function debounce<T extends (...args: any[]) => any>(
   func: T,
   delay: number,
 ): (...args: Parameters<T>) => void {
@@ -16,7 +16,7 @@ export function debounce<T extends (...args: any[] = []) => any>(
 /**
  * Throttle function to limit how often a function can be called
  */
-export function throttle<T extends (...args: any[] = []) => any>(
+export function throttle<T extends (...args: any[]) => any>(
   func: T,
   delay: number,
 ): (...args: Parameters<T>) => void {


### PR DESCRIPTION
Fix TypeScript build errors by removing illegal default initializers from rest parameters in `debounce` and `throttle` function type constraints.

---
<a href="https://cursor.com/background-agent?bcId=bc-d46a547b-5a3d-4fd5-ad5f-c65ea81eb0b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d46a547b-5a3d-4fd5-ad5f-c65ea81eb0b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

