### PR TITLE
Build project with npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "tsx": "^4.19.2",
     "typescript": "^5.9.2",
     "vite": "^7.1.3"
+  },
+  "overrides": {
+    "simple-swizzle": "0.2.2"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "installCommand": "npm install",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]


### PR DESCRIPTION
Add npm override for `simple-swizzle` and set `installCommand` to fix the build failure caused by `simple-swizzle@0.2.3` not being found in the npm registry.

---
<a href="https://cursor.com/background-agent?bcId=bc-220e8433-a967-456d-9aab-13c0c4d22ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-220e8433-a967-456d-9aab-13c0c4d22ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

