### PR TITLE
Rebuild timing.ts file from scratch

### DIFF
--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,32 +1,17 @@
 /**
- * Debounce function to limit how often a function can be called
+ * Minimal debounce helper.
  */
-export function debounce<T extends (...args: any[] = []) => any>(
-  func: T,
-  delay: number,
+export function debounce<T extends (...args: any[]) => unknown>(
+  fn: T,
+  delayMs: number,
 ): (...args: Parameters<T>) => void {
-  let timeoutId: ReturnType<typeof setTimeout>;
-
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   return (...args: Parameters<T>) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => func(...args), delay);
-  };
-}
-
-/**
- * Throttle function to limit how often a function can be called
- */
-export function throttle<T extends (...args: any[] = []) => any>(
-  func: T,
-  delay: number,
-): (...args: Parameters<T>) => void {
-  let lastCall = 0;
-
-  return (...args: Parameters<T>) => {
-    const now = Date.now();
-    if (now - lastCall >= delay) {
-      lastCall = now;
-      func(...args);
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
     }
+    timeoutId = setTimeout(() => {
+      fn(...args);
+    }, delayMs);
   };
 }


### PR DESCRIPTION
Refactor `src/utils/timing.ts` to fix TypeScript build errors and remove the unused `throttle` function.

The original `debounce` and `throttle` function type definitions in `src/utils/timing.ts` used parameter initializers (`args: any[] = []`) which are not allowed in type declarations, leading to `TS2371` and `TS1048` errors during the build. This PR simplifies the `debounce` implementation and adjusts its type signature to resolve these compilation issues, while also removing the `throttle` function which was not being used anywhere in the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-36c79223-f06c-47bc-92d6-6db16b5363ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36c79223-f06c-47bc-92d6-6db16b5363ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

