### PR TITLE
Fix lore page elemental names and images

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
     
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -982,15 +982,13 @@ export const Lore: React.FC = () => {
         <div className={s.diagramContainer}>
           <img
             className={s.diagramImage}
-            src="https://drive.google.com/uc?export=view&id=1Xt7ECRN6yNh2yefyRDAnzS6DPwbaFgNj"
+            src="/assets/lore/six-divine-elements.webp"
             alt="Six Divine Elements wheel showing Aether, Air, Fire, Earth, Water, and Nether"
             loading="lazy"
             onError={(e) => {
-              (e.target as HTMLImageElement).src =
-                "/assets/lore/six-divine-elements.webp";
+              (e.target as HTMLImageElement).src = "/assets/lore/six-divine-elements.png";
               (e.target as HTMLImageElement).onerror = () => {
-                (e.target as HTMLImageElement).src =
-                  "/assets/card-back-new.webp";
+                (e.target as HTMLImageElement).src = "/assets/card-back-new.webp";
               };
             }}
           />
@@ -1079,7 +1077,7 @@ export const Lore: React.FC = () => {
             const special = specialPairs[key];
             const ideology = special ? special.title : "Synthesis";
             const faction = getFactionForCombo(names);
-            const header = `${names.join(" + ")}: ${ideology}`;
+            const header = names.join(" + ");
             const ideologyParagraph = buildIdeologyParagraph(combo, ideology);
             const factionParagraph = buildFactionParagraph(
               faction,
@@ -1120,7 +1118,7 @@ export const Lore: React.FC = () => {
             const faction = getFactionForCombo(
               names as ElementDefinition["name"][],
             );
-            const header = `${names.join(" + ")}: ${ideology}`;
+            const header = names.join(" + ");
             const ideologyParagraph = buildIdeologyParagraph(combo, ideology);
             const factionParagraph = buildFactionParagraph(
               faction,
@@ -1161,7 +1159,7 @@ export const Lore: React.FC = () => {
             const faction = getFactionForCombo(
               names as ElementDefinition["name"][],
             );
-            const header = `${names.join(" + ")}: ${ideology}`;
+            const header = names.join(" + ");
             const ideologyParagraph = buildIdeologyParagraph(combo, ideology);
             const factionParagraph = buildFactionParagraph(
               faction,
@@ -1202,7 +1200,7 @@ export const Lore: React.FC = () => {
             const faction = getFactionForCombo(
               names as ElementDefinition["name"][],
             );
-            const header = `${names.join(" + ")}: ${ideology}`;
+            const header = names.join(" + ");
             const ideologyParagraph = buildIdeologyParagraph(combo, ideology);
             const factionParagraph = buildFactionParagraph(
               faction,


### PR DESCRIPTION
Update lore page to remove ideology from elemental combination headers and fix broken image paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ebc4fbc-79e5-4461-adc4-028e7d82603d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ebc4fbc-79e5-4461-adc4-028e7d82603d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

