### PR TITLE
Adapt cosmology and magic tabs for mobile

### DIFF
--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -1531,102 +1531,104 @@ export const Lore: React.FC = () => {
             </p>
             <div className={s.diagramCard}>
               <div className={s.tableScroll}>
-              <table className={s.matrix}>
-                <thead>
-                  <tr>
-                    <th className={s.matrixTh}>Source</th>
-                    <th className={s.matrixTh}>How it’s accessed</th>
-                    <th className={s.matrixTh}>Costs</th>
-                    <th className={s.matrixTh}>Risks</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td className={s.matrixTd}>
-                      <a href={`#${anchorId("Aether Magic System")}`}>
-                        {h("Aether")}
-                      </a>
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Vows, knots (seals), weaves (rites), counterseals")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Memory or reputation; receipts left by workings")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Ignorant bargains; the counterseal of Forgetting")}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className={s.matrixTd}>
-                      <a href={`#${anchorId("Summoning")}`}>{h("Summoning")}</a>
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Courtesy, precision, naming correctly then gently")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h(
-                        "Closing doors; payment with something expected to keep",
-                      )}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Hunger, false candles, wind that knows your name")}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className={s.matrixTd}>
-                      <a href={`#${anchorId("Alxemi (Alchemy)")}`}>
-                        {h("Alchemy")}
-                      </a>
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Seven operations that refine motive into change")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Self-change; adequacy over gold")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Moral heat; unspoken—impatience and pride")}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className={s.matrixTd}>
-                      <a href={`#${anchorId("Elements (Eastern Flavor)")}`}>
-                        {h("Elements: East/West")}
-                      </a>
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h(
-                        "Working with generative and restraining cycles; mixtures",
-                      )}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Offering the right token, rhythm, or mixture")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Mismatched cycles; doctrine cooled into dogma")}
-                    </td>
-                  </tr>
-                  <tr>
-                    <td className={s.matrixTd}>
-                      <a href={`#${anchorId("Basik AnglΣ (Language)")}`}>
-                        {h("Language")}
-                      </a>
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h(
-                        "Kind, precise speech; oaths said thrice, written once",
-                      )}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Debt to meanings marked; names bind the speaker")}
-                    </td>
-                    <td className={s.matrixTd}>
-                      {h("Ambiguity; words that roll back if wrong")}
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+                <table className={s.matrix}>
+                  <thead>
+                    <tr>
+                      <th className={s.matrixTh}>Source</th>
+                      <th className={s.matrixTh}>How it’s accessed</th>
+                      <th className={s.matrixTh}>Costs</th>
+                      <th className={s.matrixTh}>Risks</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td className={s.matrixTd}>
+                        <a href={`#${anchorId("Aether Magic System")}`}>
+                          {h("Aether")}
+                        </a>
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Vows, knots (seals), weaves (rites), counterseals")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Memory or reputation; receipts left by workings")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Ignorant bargains; the counterseal of Forgetting")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className={s.matrixTd}>
+                        <a href={`#${anchorId("Summoning")}`}>
+                          {h("Summoning")}
+                        </a>
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Courtesy, precision, naming correctly then gently")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h(
+                          "Closing doors; payment with something expected to keep",
+                        )}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Hunger, false candles, wind that knows your name")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className={s.matrixTd}>
+                        <a href={`#${anchorId("Alxemi (Alchemy)")}`}>
+                          {h("Alchemy")}
+                        </a>
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Seven operations that refine motive into change")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Self-change; adequacy over gold")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Moral heat; unspoken—impatience and pride")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className={s.matrixTd}>
+                        <a href={`#${anchorId("Elements (Eastern Flavor)")}`}>
+                          {h("Elements: East/West")}
+                        </a>
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h(
+                          "Working with generative and restraining cycles; mixtures",
+                        )}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Offering the right token, rhythm, or mixture")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Mismatched cycles; doctrine cooled into dogma")}
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className={s.matrixTd}>
+                        <a href={`#${anchorId("Basik AnglΣ (Language)")}`}>
+                          {h("Language")}
+                        </a>
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h(
+                          "Kind, precise speech; oaths said thrice, written once",
+                        )}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Debt to meanings marked; names bind the speaker")}
+                      </td>
+                      <td className={s.matrixTd}>
+                        {h("Ambiguity; words that roll back if wrong")}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
             <Disclosure title={h("Aether Magic System (full text)")}>

--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -1386,6 +1386,20 @@ export const Lore: React.FC = () => {
     return (
       <section className={s.section}>
         <h2 className={s.sectionTitle}>Cosmology & Magic</h2>
+        <details className={s.tocMobile}>
+          <summary className={s.tocMobileSummary}>On this page</summary>
+          <div className={s.tocMobileBody}>
+            <ul className={s.tocList}>
+              {tocItems.map((t) => (
+                <li key={t.id}>
+                  <a className={s.tocLink} href={`#${t.id}`}>
+                    {t.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </details>
         <nav className={s.toc} aria-label="Cosmology Table of Contents">
           <div className={s.tocTitle}>On this page</div>
           <ul className={s.tocList}>
@@ -1516,6 +1530,7 @@ export const Lore: React.FC = () => {
               )}
             </p>
             <div className={s.diagramCard}>
+              <div className={s.tableScroll}>
               <table className={s.matrix}>
                 <thead>
                   <tr>
@@ -1612,6 +1627,7 @@ export const Lore: React.FC = () => {
                   </tr>
                 </tbody>
               </table>
+              </div>
             </div>
             <Disclosure title={h("Aether Magic System (full text)")}>
               <pre id={anchorId("Aether Magic System")} className={s.pre}>

--- a/src/pages/lore.css.ts
+++ b/src/pages/lore.css.ts
@@ -293,6 +293,7 @@ export const cosmologyGrid = style({
 });
 
 export const toc = style({
+  display: "none",
   position: "sticky",
   top: "calc(env(safe-area-inset-top, 0px) + 8px)",
   backgroundColor: "#ffffff",
@@ -300,6 +301,40 @@ export const toc = style({
   borderRadius: "8px",
   padding: "10px",
   boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+  "@media": {
+    "screen and (min-width: 1024px)": { display: "block" },
+  },
+});
+
+export const tocMobile = style({
+  position: "sticky",
+  top: "calc(env(safe-area-inset-top, 0px) + 8px)",
+  backgroundColor: "#ffffff",
+  border: "1px solid #e9ecef",
+  borderRadius: "8px",
+  overflow: "hidden",
+  boxShadow: "0 1px 3px rgba(0,0,0,0.06)",
+  zIndex: 11,
+  "@media": {
+    "screen and (min-width: 1024px)": { display: "none" },
+  },
+});
+
+export const tocMobileSummary = style({
+  padding: "10px 12px",
+  cursor: "pointer",
+  userSelect: "none",
+  backgroundColor: "#f6faff",
+  borderBottom: "1px solid #eef2f6",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "8px",
+  fontWeight: 600,
+});
+
+export const tocMobileBody = style({
+  padding: "10px 12px",
 });
 
 export const tocTitle = style({
@@ -335,18 +370,25 @@ export const sectionGroup = style({
   borderRadius: "8px",
   padding: "12px",
   boxShadow: "0 2px 6px rgba(0,0,0,0.06)",
+  scrollMarginTop: "calc(env(safe-area-inset-top, 0px) + 64px)",
 });
 
 export const sectionHeader = style({
   margin: "0 0 8px 0",
   fontSize: "1.05rem",
   color: "#2c3e50",
+  "@media": {
+    "screen and (min-width: 768px)": { fontSize: "1.15rem" },
+  },
 });
 
 export const microSummary = style({
   margin: "0 0 10px 0",
   color: "#34495e",
-  fontSize: "0.98rem",
+  fontSize: "0.95rem",
+  "@media": {
+    "screen and (min-width: 640px)": { fontSize: "1rem" },
+  },
 });
 
 export const disclosure = style({
@@ -454,10 +496,17 @@ export const diagramCard = style({
   padding: "12px",
 });
 
+export const tableScroll = style({
+  width: "100%",
+  overflowX: "auto",
+  WebkitOverflowScrolling: "touch",
+});
+
 export const matrix = style({
   width: "100%",
   borderCollapse: "collapse",
   fontSize: "0.95rem",
+  minWidth: "580px",
 });
 
 export const matrixTh = style({

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -42,7 +42,7 @@ export const cardApi = {
   create: (data: any) => api.post("/cards", data),
   update: (id: string, data: any) => api.put(`/cards/${id}`, data),
   delete: (id: string) => api.delete(`/cards/${id}`),
-  bulkCreate: (data: any[] = [] = ([] = [] = [] = [])) =>
+  bulkCreate: (data: any[] = [] = ([] = [] = [] = [] = [])) =>
     api.post("/cards/bulk", data),
   getStatistics: () => api.get("/cards/statistics"),
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,6 +141,7 @@ export {};
 export {};
 export {};
 export {};
+export {};
 // Re-export all types from various type definition files
 export * from "./game";
 
@@ -203,6 +204,9 @@ export interface Card {
   color?: string;
   text?: string;
 }
+declare module "*.css";
+declare module "*.svg";
+declare module "*.png";
 declare module "*.css";
 declare module "*.svg";
 declare module "*.png";


### PR DESCRIPTION
Make the Cosmology & Magic tab mobile-friendly with a collapsible TOC and scrollable matrix table to improve usability on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-42088c85-8ea2-498c-afa8-0b0858641e0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42088c85-8ea2-498c-afa8-0b0858641e0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

