### PR TITLE
Rename magic to aether in cosmology tab

### DIFF
--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -101,7 +101,7 @@ export const Lore: React.FC = () => {
     { id: "elements", label: "Six Elements", isStatic: true },
     {
       id: "cosmology_magic",
-      label: "Cosmology & Magic",
+      label: "Cosmology & Aether",
       sources: [
         "/assets/lore/aether.txt",
         "/assets/lore/elements_east.txt",
@@ -1366,12 +1366,12 @@ export const Lore: React.FC = () => {
       const narrative = narrativeParts.join("\n\n");
       return (
         <section className={s.section}>
-          <h2 className={s.sectionTitle}>Cosmology & Magic</h2>
+          <h2 className={s.sectionTitle}>Cosmology & Aether</h2>
           <div className={s.cosmologyGrid}>
             <div className={s.sectionGroup}>
               <p className={s.microSummary}>
                 {h(
-                  "Magic is the world’s life force; formalized as science with medicine.",
+                  "Aether is the world’s life force; formalized as science with medicine.",
                 )}
               </p>
               <pre className={s.pre}>{h(narrative)}</pre>
@@ -1456,7 +1456,7 @@ export const Lore: React.FC = () => {
 
     return (
       <section className={s.section}>
-        <h2 className={s.sectionTitle}>Cosmology & Magic</h2>
+        <h2 className={s.sectionTitle}>Cosmology & Aether</h2>
         <details className={s.tocMobile} ref={tocMobileRef}>
           <summary className={s.tocMobileSummary}>On this page</summary>
           <div className={s.tocMobileBody}>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -64,6 +64,7 @@ export const cardApi = {
       [] =
       [] =
       [] =
+      [] =
         []),
   ) => api.post("/cards/bulk", data),
   getStatistics: () => api.get("/cards/statistics"),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -159,6 +159,7 @@ export {};
 export {};
 export {};
 export {};
+export {};
 // Re-export all types from various type definition files
 export * from "./game";
 
@@ -221,6 +222,9 @@ export interface Card {
   color?: string;
   text?: string;
 }
+declare module "*.css";
+declare module "*.svg";
+declare module "*.png";
 declare module "*.css";
 declare module "*.svg";
 declare module "*.png";


### PR DESCRIPTION
Replace "Magic" with "Aether" in the "Cosmology & Magic" tab to reflect that Aether is both the element and life force.

---
<a href="https://cursor.com/background-agent?bcId=bc-7639f015-fcdc-4e93-9693-3e47133812fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7639f015-fcdc-4e93-9693-3e47133812fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

