### PR TITLE
Investigate Aether page changes not applied

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Enhanced Service Worker for KONIVRER PWA - Mobile-First
-const STATIC_CACHE = "konivrer-static-v1.1.0";
-const DYNAMIC_CACHE = "konivrer-dynamic-v1.1.0";
-const IMAGE_CACHE = "konivrer-images-v1.1.0";
+const STATIC_CACHE = "konivrer-static-v1.1.1";
+const DYNAMIC_CACHE = "konivrer-dynamic-v1.1.1";
+const IMAGE_CACHE = "konivrer-images-v1.1.1";
 
 // Critical assets to cache immediately for mobile-first experience
 const STATIC_ASSETS = [
@@ -80,6 +80,12 @@ self.addEventListener("fetch", (event) => {
   } else if (request.url.includes("/static/")) {
     // Static assets - Cache First
     event.respondWith(cacheFirstStrategy(request));
+  } else if (
+    request.url.includes("/assets/lore/") &&
+    (request.url.endsWith(".txt") || request.headers.get("Accept")?.includes("text/plain"))
+  ) {
+    // Lore text files - Network First to reflect edits immediately
+    event.respondWith(networkFirstStrategy(request));
   } else {
     // HTML pages - Stale While Revalidate
     event.respondWith(staleWhileRevalidateStrategy(request));

--- a/public/sw.js
+++ b/public/sw.js
@@ -82,7 +82,8 @@ self.addEventListener("fetch", (event) => {
     event.respondWith(cacheFirstStrategy(request));
   } else if (
     request.url.includes("/assets/lore/") &&
-    (request.url.endsWith(".txt") || request.headers.get("Accept")?.includes("text/plain"))
+    (request.url.endsWith(".txt") ||
+      request.headers.get("Accept")?.includes("text/plain"))
   ) {
     // Lore text files - Network First to reflect edits immediately
     event.respondWith(networkFirstStrategy(request));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,7 +30,17 @@ window.addEventListener("orientationchange", () => {
 
 // Service worker registration for PWA features
 if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.register("/sw.js").catch(console.error);
+  if (import.meta.env.PROD) {
+    navigator.serviceWorker.register("/sw.js").catch(console.error);
+  } else {
+    // In dev: unregister existing SW and clear caches to avoid stale content
+    navigator.serviceWorker.getRegistrations().then((regs) => {
+      regs.forEach((reg) => reg.unregister());
+    });
+    if ("caches" in window) {
+      caches.keys().then((names) => names.forEach((n) => caches.delete(n)));
+    }
+  }
 }
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -72,6 +72,7 @@ export const cardApi = {
       [] =
       [] =
       [] =
+      [] =
         []),
   ) => api.post("/cards/bulk", data),
   getStatistics: () => api.get("/cards/statistics"),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -167,6 +167,7 @@ export {};
 export {};
 export {};
 export {};
+export {};
 // Re-export all types from various type definition files
 export * from "./game";
 
@@ -229,6 +230,9 @@ export interface Card {
   color?: string;
   text?: string;
 }
+declare module "*.css";
+declare module "*.svg";
+declare module "*.png";
 declare module "*.css";
 declare module "*.svg";
 declare module "*.png";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly PROD: boolean;
   readonly VITE_API_URL?: string;
 }
 


### PR DESCRIPTION
Update service worker to prevent caching of lore text files and ensure dev builds clear caches to resolve stale content issues.

The user's edits to the Aether page (which loads content from `public/assets/lore/aether.txt`) were not appearing because the service worker was serving stale cached versions of these text files. This PR bumps cache versions, sets lore text files to a network-first caching strategy, and ensures that in development environments, the service worker is unregistered and all caches are cleared to prevent such issues from recurring.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1c45356-1311-42bd-85e0-fc57e7dc289f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1c45356-1311-42bd-85e0-fc57e7dc289f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

