### PR TITLE
Prevent horizontal scrolling on Aether page

### DIFF
--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -147,7 +147,7 @@ export const Lore: React.FC = () => {
       ],
     },
   ];
-  const [activeTab, setActiveTab] = useState<string>(tabs[0].id);
+  const [activeTab] = useState<string>("aether");
   const [query, setQuery] = useState<string>("");
   const [loadedText, setLoadedText] = useState<string>("");
   const [contentByTab, setContentByTab] = useState<Record<string, string>>({});
@@ -2240,27 +2240,6 @@ export const Lore: React.FC = () => {
 
   return (
     <div className={s.container}>
-      <div className={s.header}>
-        <h1 className={s.title}>KONIVRER Lore</h1>
-        <p className={s.subtitle}>
-          Discover the rich history and mythology behind the cards
-        </p>
-      </div>
-
-      <div className={s.tabsBar}>
-        {tabs.map((t) => (
-          <button
-            key={t.id}
-            className={`${s.tabButton} ${
-              activeTab === t.id ? s.tabActive : ""
-            }`}
-            onClick={() => setActiveTab(t.id)}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
       <div className={s.content}>{renderActive()}</div>
     </div>
   );

--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -147,7 +147,7 @@ export const Lore: React.FC = () => {
       ],
     },
   ];
-  const [activeTab] = useState<string>("aether");
+  const [activeTab, setActiveTab] = useState<string>(tabs[0].id);
   const [query, setQuery] = useState<string>("");
   const [loadedText, setLoadedText] = useState<string>("");
   const [contentByTab, setContentByTab] = useState<Record<string, string>>({});
@@ -2240,6 +2240,20 @@ export const Lore: React.FC = () => {
 
   return (
     <div className={s.container}>
+      <div className={s.tabsBar}>
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            className={`${s.tabButton} ${
+              activeTab === t.id ? s.tabActive : ""
+            }`}
+            onClick={() => setActiveTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
       <div className={s.content}>{renderActive()}</div>
     </div>
   );

--- a/src/pages/lore.css.ts
+++ b/src/pages/lore.css.ts
@@ -517,17 +517,17 @@ export const diagramCard = style({
 
 export const tableScroll = style({
   width: "100%",
-  overflowX: "hidden",
+  overflowX: "auto",
   overflowY: "hidden",
   WebkitOverflowScrolling: "touch",
 });
 
 export const matrix = style({
   minWidth: "100%",
-  width: "100%",
+  width: "max-content",
   borderCollapse: "collapse",
   fontSize: "0.95rem",
-  tableLayout: "fixed",
+  tableLayout: "auto",
 });
 
 export const matrixTh = style({
@@ -535,20 +535,20 @@ export const matrixTh = style({
   padding: "8px",
   borderBottom: "2px solid #e9ecef",
   color: "#000",
-  wordBreak: "break-word",
-  overflowWrap: "anywhere",
-  hyphens: "auto",
-  whiteSpace: "normal",
+  wordBreak: "normal",
+  overflowWrap: "normal",
+  hyphens: "manual",
+  whiteSpace: "nowrap",
 });
 
 export const matrixTd = style({
   padding: "8px",
   borderBottom: "1px solid #eef2f6",
   verticalAlign: "top",
-  wordBreak: "break-word",
-  overflowWrap: "anywhere",
-  hyphens: "auto",
-  whiteSpace: "normal",
+  wordBreak: "normal",
+  overflowWrap: "normal",
+  hyphens: "manual",
+  whiteSpace: "nowrap",
 });
 
 globalStyle(`${matrixTd} a`, {

--- a/src/pages/lore.css.ts
+++ b/src/pages/lore.css.ts
@@ -517,17 +517,17 @@ export const diagramCard = style({
 
 export const tableScroll = style({
   width: "100%",
-  overflowX: "auto",
+  overflowX: "hidden",
   overflowY: "hidden",
   WebkitOverflowScrolling: "touch",
 });
 
 export const matrix = style({
   minWidth: "100%",
-  width: "max-content",
+  width: "100%",
   borderCollapse: "collapse",
   fontSize: "0.95rem",
-  tableLayout: "auto",
+  tableLayout: "fixed",
 });
 
 export const matrixTh = style({
@@ -535,9 +535,9 @@ export const matrixTh = style({
   padding: "8px",
   borderBottom: "2px solid #e9ecef",
   color: "#000",
-  wordBreak: "normal",
-  overflowWrap: "normal",
-  hyphens: "manual",
+  wordBreak: "break-word",
+  overflowWrap: "anywhere",
+  hyphens: "auto",
   whiteSpace: "normal",
 });
 
@@ -545,9 +545,9 @@ export const matrixTd = style({
   padding: "8px",
   borderBottom: "1px solid #eef2f6",
   verticalAlign: "top",
-  wordBreak: "normal",
-  overflowWrap: "normal",
-  hyphens: "manual",
+  wordBreak: "break-word",
+  overflowWrap: "anywhere",
+  hyphens: "auto",
   whiteSpace: "normal",
 });
 

--- a/src/pages/lore.css.ts
+++ b/src/pages/lore.css.ts
@@ -66,15 +66,15 @@ export const content = style({
 export const tabsBar = style({
   display: "flex",
   gap: "8px",
-  overflowX: "auto",
+  overflowX: "hidden",
+  flexWrap: "wrap",
   padding: "8px 0",
   borderBottom: "1px solid #e0e0e0",
   position: "sticky",
   top: "env(safe-area-inset-top, 0px)",
   backgroundColor: "#fff",
   zIndex: 10,
-  scrollSnapType: "x mandatory",
-  WebkitOverflowScrolling: "touch",
+  scrollSnapType: "none",
 });
 
 export const tabButton = style({
@@ -517,17 +517,17 @@ export const diagramCard = style({
 
 export const tableScroll = style({
   width: "100%",
-  overflowX: "auto",
+  overflowX: "hidden",
   overflowY: "hidden",
   WebkitOverflowScrolling: "touch",
 });
 
 export const matrix = style({
   minWidth: "100%",
-  width: "max-content",
+  width: "100%",
   borderCollapse: "collapse",
   fontSize: "0.95rem",
-  tableLayout: "auto",
+  tableLayout: "fixed",
 });
 
 export const matrixTh = style({
@@ -538,7 +538,7 @@ export const matrixTh = style({
   wordBreak: "normal",
   overflowWrap: "normal",
   hyphens: "manual",
-  whiteSpace: "nowrap",
+  whiteSpace: "normal",
 });
 
 export const matrixTd = style({
@@ -548,7 +548,7 @@ export const matrixTd = style({
   wordBreak: "normal",
   overflowWrap: "normal",
   hyphens: "manual",
-  whiteSpace: "nowrap",
+  whiteSpace: "normal",
 });
 
 globalStyle(`${matrixTd} a`, {


### PR DESCRIPTION
Remove the "KONIVRER Lore" header and eliminate all horizontal scrolling on the Aether page by making tables and tabs wrap content.

---
<a href="https://cursor.com/background-agent?bcId=bc-b43950c7-61b0-4f33-b350-28aa14568b34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b43950c7-61b0-4f33-b350-28aa14568b34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

