### PR TITLE
Add scroll indicators to caether tables

### DIFF
--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -2,6 +2,58 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import * as s from "./lore.css.ts";
 
 export const Lore: React.FC = () => {
+  function ScrollShadow({ children }: { children: React.ReactNode }) {
+    const wrapRef = useRef<HTMLDivElement | null>(null);
+    const leftRef = useRef<HTMLDivElement | null>(null);
+    const rightRef = useRef<HTMLDivElement | null>(null);
+    const hintRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      const wrap = wrapRef.current;
+      const left = leftRef.current;
+      const right = rightRef.current;
+      const hint = hintRef.current;
+      if (!wrap || !left || !right) return;
+
+      const scroller = wrap.querySelector(`.${s.tableScroll}`) as HTMLElement | null;
+      if (!scroller) return;
+
+      const update = () => {
+        const maxScroll = scroller.scrollWidth - scroller.clientWidth;
+        const x = scroller.scrollLeft;
+        const atStart = x <= 0;
+        const atEnd = x >= maxScroll - 1;
+        left.classList.toggle(s.scrollEdgeVisible, !atStart);
+        right.classList.toggle(s.scrollEdgeVisible, !atEnd);
+        if (hint) hint.style.display = maxScroll > 0 ? "inline-flex" : "none";
+      };
+
+      const onScroll = () => {
+        update();
+        if (hint) hint.style.display = "none";
+      };
+
+      update();
+      scroller.addEventListener("scroll", onScroll, { passive: true });
+      const ro = new ResizeObserver(update);
+      ro.observe(scroller);
+      return () => {
+        scroller.removeEventListener("scroll", onScroll);
+        try { ro.disconnect(); } catch {}
+      };
+    }, []);
+
+    return (
+      <div ref={wrapRef} className={s.tableScrollWrap}>
+        <div ref={leftRef} className={`${s.scrollEdge} ${s.scrollEdgeLeft}`} />
+        <div ref={rightRef} className={`${s.scrollEdge} ${s.scrollEdgeRight}`} />
+        {children}
+        <div ref={hintRef} className={s.scrollHint} aria-hidden="true">
+          ← drag →
+        </div>
+      </div>
+    );
+  }
   function TraitFooterAutoFit({ traits }: { traits: string[] }) {
     const containerRef = useRef<HTMLDivElement | null>(null);
     const innerRef = useRef<HTMLDivElement | null>(null);
@@ -1573,6 +1625,7 @@ export const Lore: React.FC = () => {
                 )}
               </p>
               <div className={s.diagramCard}>
+                <ScrollShadow>
                 <div className={s.tableScroll}>
                   <table className={s.matrix}>
                     <thead>
@@ -1681,6 +1734,7 @@ export const Lore: React.FC = () => {
                     </tbody>
                   </table>
                 </div>
+                </ScrollShadow>
               </div>
               <Disclosure title={h("Aether Magic System (full text)")}>
                 <pre id={anchorId("Aether Magic System")} className={s.pre}>
@@ -2108,6 +2162,7 @@ export const Lore: React.FC = () => {
         <div className={s.folioRule} />
 
         <div className={s.diagramCard}>
+          <ScrollShadow>
           <div className={s.tableScroll}>
             <table className={s.matrix}>
               <thead>
@@ -2131,6 +2186,7 @@ export const Lore: React.FC = () => {
               </tbody>
             </table>
           </div>
+          </ScrollShadow>
         </div>
 
         <div className={s.folioMarginNote}>
@@ -2153,6 +2209,7 @@ export const Lore: React.FC = () => {
         </div>
 
         <div className={s.diagramCard}>
+          <ScrollShadow>
           <div className={s.tableScroll}>
             <table className={s.matrix}>
               <thead>
@@ -2176,6 +2233,7 @@ export const Lore: React.FC = () => {
               </tbody>
             </table>
           </div>
+          </ScrollShadow>
         </div>
 
         <div className={s.diagramCard}>

--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -15,7 +15,9 @@ export const Lore: React.FC = () => {
       const hint = hintRef.current;
       if (!wrap || !left || !right) return;
 
-      const scroller = wrap.querySelector(`.${s.tableScroll}`) as HTMLElement | null;
+      const scroller = wrap.querySelector(
+        `.${s.tableScroll}`,
+      ) as HTMLElement | null;
       if (!scroller) return;
 
       const update = () => {
@@ -39,14 +41,19 @@ export const Lore: React.FC = () => {
       ro.observe(scroller);
       return () => {
         scroller.removeEventListener("scroll", onScroll);
-        try { ro.disconnect(); } catch {}
+        try {
+          ro.disconnect();
+        } catch {}
       };
     }, []);
 
     return (
       <div ref={wrapRef} className={s.tableScrollWrap}>
         <div ref={leftRef} className={`${s.scrollEdge} ${s.scrollEdgeLeft}`} />
-        <div ref={rightRef} className={`${s.scrollEdge} ${s.scrollEdgeRight}`} />
+        <div
+          ref={rightRef}
+          className={`${s.scrollEdge} ${s.scrollEdgeRight}`}
+        />
         {children}
         <div ref={hintRef} className={s.scrollHint} aria-hidden="true">
           ← drag →
@@ -1626,114 +1633,122 @@ export const Lore: React.FC = () => {
               </p>
               <div className={s.diagramCard}>
                 <ScrollShadow>
-                <div className={s.tableScroll}>
-                  <table className={s.matrix}>
-                    <thead>
-                      <tr>
-                        <th className={s.matrixTh}>Source</th>
-                        <th className={s.matrixTh}>How it’s accessed</th>
-                        <th className={s.matrixTh}>Costs</th>
-                        <th className={s.matrixTh}>Risks</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td className={s.matrixTd}>
-                          <a href={`#${anchorId("Aether Magic System")}`}>
-                            {h("Aether")}
-                          </a>
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Vows, knots (seals), weaves (rites), counterseals",
-                          )}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Memory or reputation; receipts left by workings")}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Ignorant bargains; the counterseal of Forgetting",
-                          )}
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className={s.matrixTd}>
-                          <a href={`#${anchorId("Summoning")}`}>
-                            {h("Summoning")}
-                          </a>
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Courtesy, precision, naming correctly then gently",
-                          )}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Closing doors; payment with something expected to keep",
-                          )}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Hunger, false candles, wind that knows your name",
-                          )}
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className={s.matrixTd}>
-                          <a href={`#${anchorId("Alxemi (Alchemy)")}`}>
-                            {h("Alchemy")}
-                          </a>
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Seven operations that refine motive into change")}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Self-change; adequacy over gold")}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Moral heat; unspoken—impatience and pride")}
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className={s.matrixTd}>
-                          <a href={`#${anchorId("Elements (Eastern Flavor)")}`}>
-                            {h("Elements: East/West")}
-                          </a>
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Working with generative and restraining cycles; mixtures",
-                          )}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Offering the right token, rhythm, or mixture")}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Mismatched cycles; doctrine cooled into dogma")}
-                        </td>
-                      </tr>
-                      <tr>
-                        <td className={s.matrixTd}>
-                          <a href={`#${anchorId("Basik AnglΣ (Language)")}`}>
-                            {h("Language")}
-                          </a>
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h(
-                            "Kind, precise speech; oaths said thrice, written once",
-                          )}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Debt to meanings marked; names bind the speaker")}
-                        </td>
-                        <td className={s.matrixTd}>
-                          {h("Ambiguity; words that roll back if wrong")}
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+                  <div className={s.tableScroll}>
+                    <table className={s.matrix}>
+                      <thead>
+                        <tr>
+                          <th className={s.matrixTh}>Source</th>
+                          <th className={s.matrixTh}>How it’s accessed</th>
+                          <th className={s.matrixTh}>Costs</th>
+                          <th className={s.matrixTh}>Risks</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td className={s.matrixTd}>
+                            <a href={`#${anchorId("Aether Magic System")}`}>
+                              {h("Aether")}
+                            </a>
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Vows, knots (seals), weaves (rites), counterseals",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Memory or reputation; receipts left by workings",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Ignorant bargains; the counterseal of Forgetting",
+                            )}
+                          </td>
+                        </tr>
+                        <tr>
+                          <td className={s.matrixTd}>
+                            <a href={`#${anchorId("Summoning")}`}>
+                              {h("Summoning")}
+                            </a>
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Courtesy, precision, naming correctly then gently",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Closing doors; payment with something expected to keep",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Hunger, false candles, wind that knows your name",
+                            )}
+                          </td>
+                        </tr>
+                        <tr>
+                          <td className={s.matrixTd}>
+                            <a href={`#${anchorId("Alxemi (Alchemy)")}`}>
+                              {h("Alchemy")}
+                            </a>
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Seven operations that refine motive into change",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h("Self-change; adequacy over gold")}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h("Moral heat; unspoken—impatience and pride")}
+                          </td>
+                        </tr>
+                        <tr>
+                          <td className={s.matrixTd}>
+                            <a
+                              href={`#${anchorId("Elements (Eastern Flavor)")}`}
+                            >
+                              {h("Elements: East/West")}
+                            </a>
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Working with generative and restraining cycles; mixtures",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h("Offering the right token, rhythm, or mixture")}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h("Mismatched cycles; doctrine cooled into dogma")}
+                          </td>
+                        </tr>
+                        <tr>
+                          <td className={s.matrixTd}>
+                            <a href={`#${anchorId("Basik AnglΣ (Language)")}`}>
+                              {h("Language")}
+                            </a>
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Kind, precise speech; oaths said thrice, written once",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h(
+                              "Debt to meanings marked; names bind the speaker",
+                            )}
+                          </td>
+                          <td className={s.matrixTd}>
+                            {h("Ambiguity; words that roll back if wrong")}
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                 </ScrollShadow>
               </div>
               <Disclosure title={h("Aether Magic System (full text)")}>
@@ -2163,29 +2178,29 @@ export const Lore: React.FC = () => {
 
         <div className={s.diagramCard}>
           <ScrollShadow>
-          <div className={s.tableScroll}>
-            <table className={s.matrix}>
-              <thead>
-                <tr>
-                  <th className={s.matrixTh}>Tradition</th>
-                  <th className={s.matrixTh}>Name for Aether</th>
-                  <th className={s.matrixTh}>Channels and Gates</th>
-                  <th className={s.matrixTh}>Balancings</th>
-                </tr>
-              </thead>
-              <tbody>
-                {doctrineRows.map((row, i) => (
-                  <tr key={i}>
-                    {row.map((cell, j) => (
-                      <td key={`${i}-${j}`} className={s.matrixTd}>
-                        {h(cell)}
-                      </td>
-                    ))}
+            <div className={s.tableScroll}>
+              <table className={s.matrix}>
+                <thead>
+                  <tr>
+                    <th className={s.matrixTh}>Tradition</th>
+                    <th className={s.matrixTh}>Name for Aether</th>
+                    <th className={s.matrixTh}>Channels and Gates</th>
+                    <th className={s.matrixTh}>Balancings</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {doctrineRows.map((row, i) => (
+                    <tr key={i}>
+                      {row.map((cell, j) => (
+                        <td key={`${i}-${j}`} className={s.matrixTd}>
+                          {h(cell)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </ScrollShadow>
         </div>
 
@@ -2210,29 +2225,29 @@ export const Lore: React.FC = () => {
 
         <div className={s.diagramCard}>
           <ScrollShadow>
-          <div className={s.tableScroll}>
-            <table className={s.matrix}>
-              <thead>
-                <tr>
-                  <th className={s.matrixTh}>Seven Lamps</th>
-                  <th className={s.matrixTh}>Seat</th>
-                  <th className={s.matrixTh}>Crossings</th>
-                  <th className={s.matrixTh}>Clinical Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {lamps.map((row, i) => (
-                  <tr key={i}>
-                    {row.map((cell, j) => (
-                      <td key={`${i}-${j}`} className={s.matrixTd}>
-                        {h(cell)}
-                      </td>
-                    ))}
+            <div className={s.tableScroll}>
+              <table className={s.matrix}>
+                <thead>
+                  <tr>
+                    <th className={s.matrixTh}>Seven Lamps</th>
+                    <th className={s.matrixTh}>Seat</th>
+                    <th className={s.matrixTh}>Crossings</th>
+                    <th className={s.matrixTh}>Clinical Notes</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {lamps.map((row, i) => (
+                    <tr key={i}>
+                      {row.map((cell, j) => (
+                        <td key={`${i}-${j}`} className={s.matrixTd}>
+                          {h(cell)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </ScrollShadow>
         </div>
 

--- a/src/pages/lore.css.ts
+++ b/src/pages/lore.css.ts
@@ -522,6 +522,55 @@ export const tableScroll = style({
   WebkitOverflowScrolling: "touch",
 });
 
+// Wrapper that provides visual scroll indicators for horizontally scrollable content
+export const tableScrollWrap = style({
+  position: "relative",
+});
+
+// Edge gradients indicating there is more content to scroll
+export const scrollEdge = style({
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  width: "16px",
+  pointerEvents: "none",
+  opacity: 0,
+  transition: "opacity 180ms ease-in-out",
+  zIndex: 2,
+});
+
+export const scrollEdgeLeft = style({
+  left: 0,
+  background: "linear-gradient(to right, rgba(0,0,0,0.10), rgba(0,0,0,0))",
+});
+
+export const scrollEdgeRight = style({
+  right: 0,
+  background: "linear-gradient(to left, rgba(0,0,0,0.10), rgba(0,0,0,0))",
+});
+
+export const scrollEdgeVisible = style({
+  opacity: 1,
+});
+
+// Small unobtrusive hint that content scrolls horizontally
+export const scrollHint = style({
+  position: "absolute",
+  bottom: "6px",
+  right: "10px",
+  padding: "2px 8px",
+  fontSize: "0.75rem",
+  borderRadius: "9999px",
+  backgroundColor: "rgba(255,255,255,0.85)",
+  border: "1px solid #e2e8f0",
+  color: "#000",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+  boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
+  zIndex: 3,
+});
+
 export const matrix = style({
   minWidth: "720px",
   width: "100%",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -83,6 +83,7 @@ export const cardApi = {
       [] =
       [] =
       [] =
+      [] =
         []),
   ) => api.post("/cards/bulk", data),
   getStatistics: () => api.get("/cards/statistics"),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -178,6 +178,7 @@ export {};
 export {};
 export {};
 export {};
+export {};
 // Re-export all types from various type definition files
 export * from "./game";
 
@@ -240,6 +241,9 @@ export interface Card {
   color?: string;
   text?: string;
 }
+declare module "*.css";
+declare module "*.svg";
+declare module "*.png";
 declare module "*.css";
 declare module "*.svg";
 declare module "*.png";


### PR DESCRIPTION
Add visual scroll indicators to tables on the Aether page to clarify horizontal scrollability.

---
<a href="https://cursor.com/background-agent?bcId=bc-78ac1945-66d4-40bf-828c-53caa58f55a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78ac1945-66d4-40bf-828c-53caa58f55a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

