### PR TITLE
Build project with errors

### DIFF
--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -28,18 +28,6 @@ interface Event {
   registrationDeadline?: string;
 }
 
-interface User {
-  id: string;
-  username: string;
-  role:
-    | "player"
-    | "judge_l1"
-    | "judge_l2"
-    | "judge_l3"
-    | "tournament_organizer"
-    | "admin";
-  isAuthenticated?: boolean;
-}
 
 export const Events: React.FC = () => {
   const [activeTab, setActiveTab] = useState<"my-events" | "create" | "admin">(
@@ -48,7 +36,7 @@ export const Events: React.FC = () => {
   const [viewMode, setViewMode] = useState<"upcoming" | "live" | "past">(
     "upcoming",
   );
-  const [events, setEvents] = useState<Event[]>([]);
+  const [events] = useState<Event[]>([]);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
   const [timeFrame, setTimeFrame] = useState<{
@@ -199,10 +187,6 @@ export const Events: React.FC = () => {
     }
   };
 
-  const handleEventUnregister = (eventId: string) => {
-    // Unregister from event
-    console.log("Unregister from event:", eventId);
-  };
 
   const renderEventCard = (event: Event) => (
     <div

--- a/src/pages/events.css.ts
+++ b/src/pages/events.css.ts
@@ -117,9 +117,10 @@ export const advancedSearchButton = style({
   cursor: "pointer",
   fontSize: "0.9rem",
   transition: "all 0.2s ease",
-  ":hover": {
-    background: "var(--border-color)",
-  },
+});
+
+globalStyle(`${advancedSearchButton}:hover`, {
+  background: "var(--border-color)",
 });
 
 export const advancedSearchPanel = style({
@@ -167,9 +168,10 @@ export const applySearchButton = style({
   cursor: "pointer",
   fontSize: "0.9rem",
   transition: "all 0.2s ease",
-  ":hover": {
-    background: "var(--accent-hover, #0056b3)",
-  },
+});
+
+globalStyle(`${applySearchButton}:hover`, {
+  background: "var(--accent-hover, #0056b3)",
 });
 
 export const selectedEventView = style({
@@ -195,9 +197,10 @@ export const backButton = style({
   cursor: "pointer",
   fontSize: "0.9rem",
   transition: "all 0.2s ease",
-  ":hover": {
-    background: "var(--border-color)",
-  },
+});
+
+globalStyle(`${backButton}:hover`, {
+  background: "var(--border-color)",
 });
 
 export const eventPairings = style({
@@ -209,8 +212,9 @@ export const eventPairings = style({
 globalStyle(`${eventCard}`, {
   cursor: "pointer",
   transition: "all 0.2s ease",
-  ":hover": {
-    background: "var(--hover-bg, rgba(255,255,255,0.05))",
-    borderColor: "var(--accent-color, #007bff)",
-  },
+});
+
+globalStyle(`${eventCard}:hover`, {
+  background: "var(--hover-bg, rgba(255,255,255,0.05))",
+  borderColor: "var(--accent-color, #007bff)",
 });


### PR DESCRIPTION
Resolve TypeScript compilation errors by removing unused declarations and updating vanilla-extract CSS hover syntax.

The vanilla-extract library does not support `:hover` pseudo-selectors directly within style objects. This PR updates the CSS to use `globalStyle` for hover effects, resolving a `TS2353` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5d6740f-a920-4834-bb7f-338e6a921040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5d6740f-a920-4834-bb7f-338e6a921040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

