### PR TITLE
Build project with typescript error

### DIFF
--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -225,7 +225,7 @@ const EventList: React.FC = () => {
   };
 
   const groupEventsByStore = (events: Event[]) => {
-    const grouped: { [key: string]: { store: any = {}; events: Event[] } } = {};
+    const grouped: { [key: string]: { store: any; events: Event[] } } = {};
     const onlineEvents: Event[] = [];
 
     events.forEach((event) => {


### PR DESCRIPTION
Remove initializer from type literal property to fix TypeScript build error TS1247.

The previous code `store: any = {}` in the type definition was attempting to initialize a property within a type literal, which is not allowed in TypeScript. This change corrects the type definition to `store: any`, resolving the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-658f74fe-383b-4d37-a986-1f8a4f76a63d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-658f74fe-383b-4d37-a986-1f8a4f76a63d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

