### PR TITLE
Fix code style issues in build

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export {};
 // Re-export all types from various type definition files
 export * from "./game";
 
@@ -139,3 +140,6 @@ export interface SearchFilters {
 declare module "*.css";
 declare module "*.svg";
 declare module "*.png";
+declare module '*.css';
+declare module '*.svg';
+declare module '*.png';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,3 @@
-export {};
-export {};
-export {};
-export {};
-export {};
 // Re-export all types from various type definition files
 export * from "./game";
 
@@ -144,18 +139,3 @@ export interface SearchFilters {
 declare module "*.css";
 declare module "*.svg";
 declare module "*.png";
-declare module "*.css";
-declare module "*.svg";
-declare module "*.png";
-declare module "*.css";
-declare module "*.svg";
-declare module "*.png";
-declare module "*.css";
-declare module "*.svg";
-declare module "*.png";
-declare module "*.css";
-declare module "*.svg";
-declare module "*.png";
-declare module '*.css';
-declare module '*.svg';
-declare module '*.png';


### PR DESCRIPTION
Remove duplicate `export {}` and `declare module` statements in `src/types/index.ts` to resolve Prettier formatting errors and enable successful Vercel builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7d97fbc-23be-4c42-9a10-be5feadd5dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7d97fbc-23be-4c42-9a10-be5feadd5dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

