### PR TITLE
Move category dropdown next to advanced search

### DIFF
--- a/src/mobile/SearchBar.tsx
+++ b/src/mobile/SearchBar.tsx
@@ -736,6 +736,28 @@ export const SearchBar: React.FC<Props> = ({
             {showAdvancedSearch ? "▲" : "▼"}
           </span>
         </button>
+        {current === "lore" && (
+          <select
+            className={s.loreCategorySelect}
+            aria-label="Lore category"
+            onChange={(e) => {
+              const tabId = e.target.value;
+              window.dispatchEvent(
+                new CustomEvent("lore-tab-change", { detail: tabId }),
+              );
+            }}
+            defaultValue=""
+          >
+            <option value="" disabled>
+              Category
+            </option>
+            <option value="elements">Six Elements</option>
+            <option value="aether">Aether Treatise</option>
+            <option value="cosmology">Cosmology</option>
+            <option value="pantheons_species">Pantheons & Species</option>
+            <option value="societies_eras">Societies & Eras</option>
+          </select>
+        )}
         {(current === "decks" || current === "my-decks") && onBuildDeck && (
           <button onClick={onBuildDeck} className={s.buildDeckButton}>
             Build Deck

--- a/src/mobile/searchBar.css.ts
+++ b/src/mobile/searchBar.css.ts
@@ -212,3 +212,14 @@ export const applySearchButton = style({
   transition: "all 0.2s ease",
   width: "100%",
 });
+
+export const loreCategorySelect = style({
+  background: "var(--secondary-bg, rgba(255,255,255,0.1))",
+  color: "var(--text-primary)",
+  border: "1px solid rgba(255,255,255,0.12)",
+  borderRadius: 8,
+  padding: "0.5rem 0.75rem",
+  fontSize: 14,
+  minHeight: 36,
+  cursor: "pointer",
+});

--- a/src/pages/Lore.tsx
+++ b/src/pages/Lore.tsx
@@ -150,7 +150,7 @@ const labelForSrc: Record<string, string> = {
 };
 
 export const Lore: React.FC = () => {
-  function ScrollShadow({ children }: { children: React.ReactNode }) {
+  function ScrollShadow({ children }: { children?: React.ReactNode }) {
     const wrapRef = useRef<HTMLDivElement | null>(null);
     const leftRef = useRef<HTMLDivElement | null>(null);
     const rightRef = useRef<HTMLDivElement | null>(null);
@@ -309,6 +309,17 @@ export const Lore: React.FC = () => {
     const handler = (e: Event) => setQuery((e as CustomEvent).detail || "");
     window.addEventListener("lore-search", handler);
     return () => window.removeEventListener("lore-search", handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const tabId = (e as CustomEvent).detail as string;
+      if (typeof tabId === "string") {
+        setActiveTab(tabId);
+      }
+    };
+    window.addEventListener("lore-tab-change", handler);
+    return () => window.removeEventListener("lore-tab-change", handler);
   }, []);
 
   useEffect(() => {
@@ -1578,20 +1589,6 @@ export const Lore: React.FC = () => {
 
   return (
     <div className={s.container}>
-      <div className={s.tabsBar}>
-        <select
-          value={activeTab}
-          onChange={(e) => setActiveTab(e.target.value)}
-          className={s.tabDropdown}
-        >
-          {tabs.map((t) => (
-            <option key={t.id} value={t.id}>
-              {t.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
       <div className={s.content}>{renderActive()}</div>
     </div>
   );


### PR DESCRIPTION
Move the Lore page category dropdown to the global search bar next to the Advanced Search toggle.

---
<a href="https://cursor.com/background-agent?bcId=bc-c72ecaa7-8cb5-4b78-a931-3ec9d5c4877a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c72ecaa7-8cb5-4b78-a931-3ec9d5c4877a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

