### PR TITLE
Make buttons solid and not transparent

### DIFF
--- a/src/mobile/mobileNav.css.ts
+++ b/src/mobile/mobileNav.css.ts
@@ -37,7 +37,6 @@ export const tab = style({
   cursor: "pointer",
   borderRight: "1px solid var(--border-color)",
   selectors: {
-    "&:active": { opacity: 0.8 },
     "&:hover": {
       background: "rgba(0,0,0,0.08)",
     },


### PR DESCRIPTION
Remove opacity change on mobile nav tab active state to make clicked buttons solid.

Previously, mobile navigation tabs would become partially transparent when clicked, which was inconsistent with other buttons. This change ensures that when a mobile nav button is pressed, it remains solid, matching the expected behavior of regular buttons (e.g., the "Home" button).

---
<a href="https://cursor.com/background-agent?bcId=bc-d9a4e035-9e88-4893-b3b5-7eeafa11551b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9a4e035-9e88-4893-b3b5-7eeafa11551b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

