### PR TITLE
Manage navigation button state and styling

### DIFF
--- a/src/mobile/MobileNav.tsx
+++ b/src/mobile/MobileNav.tsx
@@ -81,7 +81,7 @@ export const MobileNav: React.FC<Props> = ({ current, onNavigate }) => {
             </button>
           );
         })()}
-        {/* Swapped: show Lore before Sim */}
+        {/* Swapped: show Lore before Sim; when on Lore or Sim, that slot becomes Home */}
         {(
           [
             ...(isAuthenticated ? [["my-decks", "My Decks"] as const] : []),
@@ -89,16 +89,23 @@ export const MobileNav: React.FC<Props> = ({ current, onNavigate }) => {
             ["simulator", "Sim"] as const,
             ...(canAccessJudgePortal() ? [["judge", "Judge"] as const] : []),
           ] as const
-        ).map(([page, label]) => (
-          <button
-            key={page}
-            className={`${s.tab} ${active(page as Tab)}`}
-            aria-current={current === page}
-            onClick={() => onNavigate(page)}
-          >
-            <span className={s.label}>{label}</span>
-          </button>
-        ))}
+        ).map(([page, defaultLabel]) => {
+          const isLoreOrSim = page === "lore" || page === "simulator";
+          const isCurrent = current === page;
+          const isReplacedByHome = isLoreOrSim && isCurrent;
+          const label = isReplacedByHome ? "Home" : defaultLabel;
+          const target = isReplacedByHome ? "home" : page;
+          return (
+            <button
+              key={page}
+              className={`${s.tab} ${isReplacedByHome ? s.tabHome : active(page as Tab)}`}
+              aria-current={!isReplacedByHome && current === page}
+              onClick={() => onNavigate(target)}
+            >
+              <span className={s.label}>{label}</span>
+            </button>
+          );
+        })}
         {/* Login button moved after Lore */}
         <button
           className={`${s.tab}`}

--- a/src/mobile/mobileNav.css.ts
+++ b/src/mobile/mobileNav.css.ts
@@ -59,6 +59,22 @@ export const tabHomeActive = style({
   border: "1px solid #000",
 });
 
+// Styling for Home button when used as a replacement in other slots
+export const tabHome = style({
+  color: "#000",
+  background: "#fff",
+  selectors: {
+    "&:hover": {
+      background: "#fff",
+      color: "#000",
+    },
+    "&:active": {
+      background: "#fff",
+      color: "#000",
+    },
+  },
+});
+
 export const label = style({
   fontSize: 11,
   marginTop: 4,


### PR DESCRIPTION
Replace the Lore and Simulator navigation buttons with a persistent, styled Home button when their respective pages are active, as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb29c78d-740a-4777-935d-65e9d3c1e3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb29c78d-740a-4777-935d-65e9d3c1e3cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

