### PR TITLE
Style home button white with black text

### DIFF
--- a/src/mobile/MobileNav.tsx
+++ b/src/mobile/MobileNav.tsx
@@ -48,11 +48,13 @@ export const MobileNav: React.FC<Props> = ({ current, onNavigate }) => {
             <button
               key={id}
               className={`${s.tab} ${
-                current === id 
-                  ? id === "home" 
-                    ? s.tabHomeActive 
-                    : s.tabActive 
-                  : ""
+                id === "home"
+                  ? current === "home"
+                    ? s.tabHomeActive
+                    : s.tabHome
+                  : current === id
+                    ? s.tabActive
+                    : ""
               }`}
               aria-current={current === id}
               onClick={() => onNavigate(id)}
@@ -67,13 +69,7 @@ export const MobileNav: React.FC<Props> = ({ current, onNavigate }) => {
           const target = isRules ? "home" : "rules";
           return (
             <button
-              className={`${s.tab} ${
-                !isRules 
-                  ? active("rules") 
-                  : current === "home" 
-                    ? s.tabHomeActive 
-                    : ""
-              }`}
+              className={`${s.tab} ${isRules ? s.tabHome : active("rules")}`}
               aria-current={!isRules && current === "rules"}
               onClick={() => onNavigate(target)}
             >


### PR DESCRIPTION
Apply `s.tabHome` style to the "Home" button when it replaces another tab to ensure consistent styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-13fa3d7b-d763-437d-8e27-11be70ec8a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-13fa3d7b-d763-437d-8e27-11be70ec8a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

