### PR TITLE
Handle card search 404 error

### DIFF
--- a/backend/src/cards/cards.controller.ts
+++ b/backend/src/cards/cards.controller.ts
@@ -21,7 +21,7 @@ import { CreateCardDto, UpdateCardDto, CardFilterDto } from "./dto/card.dto";
 import { Card } from "./entities/card.entity";
 
 @ApiTags("cards")
-@Controller("api/cards")
+@Controller("cards")
 export class CardsController {
   constructor(private readonly cardsService: CardsService) {}
 
@@ -142,27 +142,27 @@ export class CardsController {
 
     const result = await this.cardsService.findAll(internalFilters);
 
-    // Return in API spec format
+    // Return in PaginatedResponse shape expected by frontend
     return {
-      total: result.total,
-      page: result.page,
-      pageSize: result.limit,
-      cards: (result.items || []).map((card) => ({
+      data: (result.items || []).map((card) => ({
         id: card.id,
         name: card.name,
         type: card.type,
         cost: card.cost,
-        faction: card.element, // Map element to faction (legacy)
-        element: card.element, // Include element for modern clients
+        faction: card.element,
+        element: card.element,
         rarity: card.rarity,
         text: card.description,
         imageUrl: card.imageUrl,
         webpUrl: card.webpUrl,
         metadata: {
           rarity: card.rarity,
-          set: filters.set || "S1", // Default set
+          set: filters.set || "S1",
         },
       })),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
     };
   }
 


### PR DESCRIPTION
Fix 404 error for card search by correcting the `CardsController` path and aligning its response shape with the `PaginatedResponse` expected by the frontend.

The 404 occurred because the `CardsController` had a redundant `api/` prefix in its `@Controller` decorator, causing the effective endpoint to be `/api/v1/api/cards` instead of the expected `/api/v1/cards`. Additionally, the `findAll` method's return structure was updated to match the `PaginatedResponse` interface, which the frontend's `useCards` hook expects, resolving data parsing issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-2758fccd-c8eb-4670-a2d4-3efdbf7c04e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2758fccd-c8eb-4670-a2d4-3efdbf7c04e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

