### PR TITLE
Investigate card search 404 error

### DIFF
--- a/src/hooks/useCards.ts
+++ b/src/hooks/useCards.ts
@@ -10,7 +10,7 @@ export interface UseCardsOptions {
 }
 
 export function useCards(options: UseCardsOptions = {}) {
-  const { search, filters, enabled = true } = options;
+  const { search, filters = {}, enabled = true } = options;
   const queryClient = useQueryClient();
 
   const {
@@ -55,7 +55,7 @@ export function useCards(options: UseCardsOptions = {}) {
   });
 
   return {
-    cards: cardsData?.data || [],
+    cards: cardsData?.data?.data || [],
     total: cardsData?.data?.total || 0,
     isLoading,
     error: error?.message || null,


### PR DESCRIPTION
Add local card data fallback to `CardSearch` and normalize `useCards` API response to prevent 404 errors from breaking the UI.

The `CardSearch` component previously displayed a hard error screen when the backend API returned a 404. This PR introduces `useLocalCards` as an automatic fallback, allowing the application to display local card data instead of an error. `useCards` was also updated to safely handle default filter options and correctly extract data from the API response, improving overall robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcb108fd-6299-468c-a9b9-07649fb96b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dcb108fd-6299-468c-a9b9-07649fb96b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

