### PR TITLE
Fix card image attachment to search

### DIFF
--- a/src/components/CardSearch.tsx
+++ b/src/components/CardSearch.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "../stores/appStore";
 import { Card } from "../data/cards"; // Use our local Card type
 import * as cs from "./cardSearch.css.ts";
 import { CardViewerModal } from "./CardViewerModal";
+import { resolveCardImageUrls } from "../utils/cardImages";
 // nav header removed along with redundant filters
 
 interface CardSearchProps {
@@ -75,11 +76,12 @@ export const CardSearch: React.FC<CardSearchProps> = () => {
               onClick={() => setSelectedCard(card)}
             >
               <picture>
-                {card.webpUrl ? (
-                  <source srcSet={card.webpUrl} type="image/webp" />
-                ) : null}
+                {(() => {
+                  const { webpSrc } = resolveCardImageUrls(card);
+                  return <source srcSet={webpSrc} type="image/webp" />;
+                })()}
                 <img
-                  src={card.imageUrl || "/assets/card-back-new.png"}
+                  src={(() => resolveCardImageUrls(card).imgSrc)()}
                   alt={card.name}
                   className={cs.cardImg}
                   onError={(e) => {

--- a/src/utils/cardImages.ts
+++ b/src/utils/cardImages.ts
@@ -1,0 +1,34 @@
+import type { Card } from "../data/cards";
+
+function extractBaseFromPath(path: string): string | null {
+  try {
+    const last = path.split("/").pop();
+    if (!last) return null;
+    const base = last.replace(/\.(png|jpg|jpeg|webp|svg)$/i, "");
+    return base || null;
+  } catch {
+    return null;
+  }
+}
+
+function deriveBaseNameFromCard(card: Pick<Card, "name"> & Partial<Card>): string {
+  const candidates: Array<string | undefined> = [card.webpUrl, card.imageUrl];
+  for (const c of candidates) {
+    if (!c) continue;
+    const base = extractBaseFromPath(c);
+    if (base) return base.toUpperCase();
+  }
+
+  // Fallback: derive from display name by stripping non-alphanumerics and uppercasing
+  const normalized = card.name.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
+  return normalized;
+}
+
+export function resolveCardImageUrls(card: Card): { webpSrc: string; imgSrc: string } {
+  const base = deriveBaseNameFromCard(card);
+  const webpSrc = `/assets/cards/${base}.webp`;
+  // Prefer WebP for both <source> and <img> to avoid broken PNG references
+  const imgSrc = webpSrc;
+  return { webpSrc, imgSrc };
+}
+


### PR DESCRIPTION
Normalize card image URLs to consistently display images in search results.

Previously, card images often failed to load in search results due to inconsistencies between `card.imageUrl`/`card.webpUrl` and the actual filenames in `public/assets/cards`, which are all uppercase WebP files. This change introduces a utility to derive a consistent image path based on the card's name, ensuring images are correctly displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae84fa1e-83ea-445a-877b-503a8ad3d42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae84fa1e-83ea-445a-877b-503a8ad3d42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

