### PR TITLE
Fix broken card image links

### DIFF
--- a/src/components/CardDetail.tsx
+++ b/src/components/CardDetail.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card } from "../data/cards";
 import * as st from "./cardDetail.css.ts";
+import { resolveCardImageUrls } from "../utils/cardImages";
 
 interface CardDetailProps {
   card: Card;
@@ -19,11 +20,12 @@ export const CardDetail: React.FC<CardDetailProps> = ({ card, onClose }) => {
           <div className={st.imageSection}>
             <h2>{card.name}</h2>
             <picture>
-              {card.webpUrl ? (
-                <source srcSet={card.webpUrl} type="image/webp" />
-              ) : null}
+              {(() => {
+                const { webpSrc } = resolveCardImageUrls(card);
+                return <source srcSet={webpSrc} type="image/webp" />;
+              })()}
               <img
-                src={card.imageUrl || "/assets/card-back-new.png"}
+                src={(() => resolveCardImageUrls(card).imgSrc)()}
                 alt={card.name}
                 className={st.cardImage}
                 onError={(e) => {

--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Card } from "../types";
 import * as overlay from "../appOverlay.css.ts";
+import { resolveCardImageUrls } from "../utils/cardImages";
 
 interface CardModalProps {
   card: Card | null;
@@ -22,11 +23,12 @@ export function CardModal({ card, onClose }: CardModalProps) {
         </button>
         <h2>{card.name}</h2>
         <picture>
-          {card.webpUrl ? (
-            <source srcSet={card.webpUrl} type="image/webp" />
-          ) : null}
+          {(() => {
+            const { webpSrc } = resolveCardImageUrls(card);
+            return <source srcSet={webpSrc} type="image/webp" />;
+          })()}
           <img
-            src={card.imageUrl || "/assets/card-back-new.png"}
+            src={(() => resolveCardImageUrls(card).imgSrc)()}
             alt={card.name}
             className={overlay.modalImg}
             onError={(e) => {

--- a/src/components/DeckSearch.tsx
+++ b/src/components/DeckSearch.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useMemo } from "react";
 import * as nav from "../nav.css.ts";
 import * as ds from "./deckSearch.css.ts";
-import { Deck, cardDatabase } from "../data/cards";
+import { Deck, cardDatabase, type Card } from "../data/cards";
 import { DeckBuilderAdvanced } from "../pages/DeckBuilderAdvanced";
 import { useAppStore } from "../stores/appStore";
+import { resolveCardImageUrls } from "../utils/cardImages";
 
 interface DeckSearchProps {
   onDeckSelect?: (deck: Deck) => void;
@@ -50,7 +51,7 @@ export const DeckSearch: React.FC<DeckSearchProps> = ({ onDeckSelect }) => {
     return deck.cards
       .slice(0, 3)
       .map((cardId) => cardDatabase.find((card) => card.id === cardId))
-      .filter(Boolean);
+      .filter((c): c is Card => Boolean(c));
   };
 
   const handleAddToMyAccount = (deck: Deck) => {
@@ -86,7 +87,7 @@ export const DeckSearch: React.FC<DeckSearchProps> = ({ onDeckSelect }) => {
                   {previewCards.map((card, index) => (
                     <img
                       key={card?.id}
-                      src={card?.webpUrl}
+                      src={card ? resolveCardImageUrls(card).imgSrc : undefined}
                       alt={card?.name}
                       style={{
                         width: `${100 / previewCards.length}%`,
@@ -96,9 +97,10 @@ export const DeckSearch: React.FC<DeckSearchProps> = ({ onDeckSelect }) => {
                       }}
                       className={ds.previewImg}
                       onError={(e) => {
-                        // Fallback to PNG if WebP fails
-                        if (card) {
-                          (e.target as HTMLImageElement).src = card.imageUrl;
+                        if (!card) return;
+                        const img = e.target as HTMLImageElement;
+                        if (!img.src.endsWith("/assets/card-back-new.png")) {
+                          img.src = "/assets/card-back-new.png";
                         }
                       }}
                     />

--- a/src/utils/cardImages.ts
+++ b/src/utils/cardImages.ts
@@ -11,17 +11,25 @@ function extractBaseFromPath(path: string): string | null {
   }
 }
 
+function sanitizeDisplayName(name: string): string {
+  return name.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
+}
+
 function deriveBaseNameFromCard(card: Pick<Card, "name"> & Partial<Card>): string {
+  // Prefer deriving from the human-readable display name to match local asset naming
+  const fromName = sanitizeDisplayName(card.name);
+  if (fromName) return fromName;
+
+  // Fallback: try to extract from provided URLs (backend may return mismatched paths)
   const candidates: Array<string | undefined> = [card.webpUrl, card.imageUrl];
   for (const c of candidates) {
     if (!c) continue;
     const base = extractBaseFromPath(c);
-    if (base) return base.toUpperCase();
+    if (base) return sanitizeDisplayName(base);
   }
 
-  // Fallback: derive from display name by stripping non-alphanumerics and uppercasing
-  const normalized = card.name.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
-  return normalized;
+  // Final fallback
+  return "";
 }
 
 export function resolveCardImageUrls(card: Card): { webpSrc: string; imgSrc: string } {


### PR DESCRIPTION
Fix broken card search images by updating resolution logic to consistently use local web-optimized WebP assets with robust fallbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-4683de05-76fd-4eee-b9a9-4690cdd3fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4683de05-76fd-4eee-b9a9-4690cdd3fcdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

