### PR TITLE
Remove blue bar from advanced search

### DIFF
--- a/src/mobile/SearchBar.tsx
+++ b/src/mobile/SearchBar.tsx
@@ -725,7 +725,7 @@ export const SearchBar: React.FC<Props> = ({
         />
       </div>
 
-      {/* Advanced Search Toggle and Build Deck Button */}
+      {/* Advanced Search Toggle */}
       <div className={s.advancedSearchToggle}>
         <button
           onClick={() => setShowAdvancedSearch(!showAdvancedSearch)}
@@ -757,11 +757,6 @@ export const SearchBar: React.FC<Props> = ({
             <option value="pantheons_species">Pantheons & Species</option>
             <option value="societies_eras">Societies & Eras</option>
           </select>
-        )}
-        {(current === "decks" || current === "my-decks") && onBuildDeck && (
-          <button onClick={onBuildDeck} className={s.buildDeckButton}>
-            Build Deck
-          </button>
         )}
       </div>
 


### PR DESCRIPTION
Remove the "Build Deck" button to eliminate the blue bar below the advanced search on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c84a22c7-6d18-48a8-9d13-6cdf6f41495b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c84a22c7-6d18-48a8-9d13-6cdf6f41495b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

