### PR TITLE
Restore build deck button on deck page

### DIFF
--- a/src/mobile/SearchBar.tsx
+++ b/src/mobile/SearchBar.tsx
@@ -736,6 +736,16 @@ export const SearchBar: React.FC<Props> = ({
             {showAdvancedSearch ? "▲" : "▼"}
           </span>
         </button>
+        {current === "decks" && (
+          <button
+            onClick={() => onBuildDeck?.()}
+            className={s.buildDeckButton}
+            aria-label="Build Deck"
+            title="Build Deck"
+          >
+            Build Deck
+          </button>
+        )}
         {current === "lore" && (
           <select
             className={s.loreCategorySelect}


### PR DESCRIPTION
Restore the 'Build Deck' button next to the 'Advanced Search' button on the deck page.

---
<a href="https://cursor.com/background-agent?bcId=bc-c635bbe7-dc3a-4a6c-9ef4-ea948d779840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c635bbe7-dc3a-4a6c-9ef4-ea948d779840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

