### PR TITLE
Show create event button for organizers only

### DIFF
--- a/src/pages/CompanionPage.tsx
+++ b/src/pages/CompanionPage.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { useAuth } from "../hooks/useAuth";
+import { UserRole } from "../services/authService";
 
 export interface CompanionPageProps {
   userId?: string;
@@ -10,6 +12,9 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
   );
 
   // TODO: Implement actual user authentication and role management
+
+  const { hasRole } = useAuth();
+  const isOrganizer = hasRole(UserRole.TOURNAMENT_ORGANIZER);
 
   // Mock event data - in real app this would come from API
   const activeEvents = [
@@ -318,12 +323,14 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
         >
           📅 Active Events
         </button>
-        <button
-          className={`tab-button ${activeTab === "create" ? "active" : ""}`}
-          onClick={() => setActiveTab("create")}
-        >
-          ➕ Create Event
-        </button>
+        {isOrganizer && (
+          <button
+            className={`tab-button ${activeTab === "create" ? "active" : ""}`}
+            onClick={() => setActiveTab("create")}
+          >
+            ➕ Create Event
+          </button>
+        )}
         <button
           className={`tab-button ${activeTab === "history" ? "active" : ""}`}
           onClick={() => setActiveTab("history")}
@@ -390,7 +397,7 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
           </div>
         )}
 
-        {activeTab === "create" && (
+        {isOrganizer && activeTab === "create" && (
           <div>
             <h2>Create New Event</h2>
             <p>


### PR DESCRIPTION
Conditionally render the 'Create Event' button and its content to be visible only to tournament organizers.

---
<a href="https://cursor.com/background-agent?bcId=bc-69e016ce-d511-4f03-80e1-02f95f984c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69e016ce-d511-4f03-80e1-02f95f984c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

