### PR TITLE
Style home button to be solid white

### DIFF
--- a/src/components/bubbleMenu.css.ts
+++ b/src/components/bubbleMenu.css.ts
@@ -117,7 +117,10 @@ export const menuItem = style({
   transition: "all 0.2s ease",
   fontSize: 16,
   width: "100%",
-  selectors: { "&:hover": { background: "rgba(255,255,255,0.05)" } },
+  selectors: {
+    "&:hover": { background: "rgba(255,255,255,0.05)" },
+    "&:active": { background: "#fff", color: "#000" },
+  },
 });
 export const menuItemActive = style({
   background: "var(--accent-color)",

--- a/src/mobile/mobileNav.css.ts
+++ b/src/mobile/mobileNav.css.ts
@@ -40,10 +40,7 @@ export const tab = style({
     "&:hover": {
       background: "rgba(0,0,0,0.08)",
     },
-    "&:active": {
-      background: "#fff",
-      color: "#000",
-    },
+    "&:active": { background: "#fff", color: "#000" },
   },
 });
 
@@ -64,14 +61,8 @@ export const tabHome = style({
   color: "#000",
   background: "#fff",
   selectors: {
-    "&:hover": {
-      background: "#fff",
-      color: "#000",
-    },
-    "&:active": {
-      background: "#fff",
-      color: "#000",
-    },
+    "&:hover": { background: "#fff", color: "#000" },
+    "&:active": { background: "#fff", color: "#000" },
   },
 });
 


### PR DESCRIPTION
Ensure the Home button in the menu and bottom navigation displays with a solid white background and black text when active.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d94350d-733b-4471-8cfd-fe4d32fcf65b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d94350d-733b-4471-8cfd-fe4d32fcf65b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

