### PR TITLE
Crawl repository for pdfs

### DIFF
--- a/src/pages/PdfViewer.tsx
+++ b/src/pages/PdfViewer.tsx
@@ -1,66 +1,21 @@
-import { useEffect, useRef } from "react";
+import React, { type JSX } from "react";
 import * as s from "./pdfViewer.css.ts";
-
-// Worker source will be configured after dynamic import
 
 export function PdfViewer({
   url = "/sample.pdf",
 }: {
   url?: string;
-}): React.JSX.Element {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-
-  useEffect(() => {
-    let isCancelled = false;
-    let pdfDoc: unknown = null;
-
-    (async () => {
-      const pdfjs = await import("pdfjs-dist");
-      pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js`;
-      const loadingTask = pdfjs.getDocument(url);
-      pdfDoc = await loadingTask.promise;
-      if (isCancelled) return;
-
-      // Render first page for simple viewer parity
-      const page = await (
-        pdfDoc as {
-          getPage: (pageNumber: number) => Promise<{
-            getViewport: (options: { scale: number }) => {
-              width: number;
-              height: number;
-            };
-            render: (options: {
-              canvasContext: CanvasRenderingContext2D;
-              viewport: { width: number; height: number };
-            }) => { promise: Promise<void> };
-          }>;
-        }
-      ).getPage(1);
-      const viewport = page.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const context = canvas.getContext("2d");
-      if (!context) return;
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-
-      await page.render({
-        canvasContext: context,
-        viewport: viewport,
-      }).promise;
-    })();
-
-    return () => {
-      isCancelled = true;
-      // pdf.js cleans up internally when loadingTask is abandoned
-    };
-  }, [url]);
-
+}): JSX.Element {
   return (
     <div className={s.viewerWrap}>
       <div className={s.toolbar}></div>
       <div className={s.canvasWrap}>
-        <canvas ref={canvasRef} className={s.canvas} />
+        <iframe
+          src={url}
+          title="Embedded PDF"
+          className={s.frame}
+          loading="lazy"
+        />
       </div>
     </div>
   );

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -1,7 +1,42 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { PdfViewer } from "./PdfViewer";
 
 export const Rules: React.FC = () => {
-  // Render PDF viewer with canonical rules PDF path
-  return <PdfViewer url="/assets/konivrer-rules.pdf" />;
+  const documents = useMemo(
+    () =>
+      [
+        { label: "Rules", value: "/assets/konivrer-rules.pdf" },
+        { label: "Tournament Rules", value: "/assets/konivrer-tournament-rules.pdf" },
+        { label: "Code of Conduct", value: "/assets/konivrer-code-of-conduct.pdf" },
+      ],
+    [],
+  );
+
+  const [selectedUrl, setSelectedUrl] = useState<string>(documents[0].value);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <label htmlFor="rules-doc-select" style={{ fontWeight: 600 }}>
+          Document
+        </label>
+        <select
+          id="rules-doc-select"
+          aria-label="Select rules document"
+          value={selectedUrl}
+          onChange={(e) => setSelectedUrl(e.target.value)}
+        >
+          {documents.map((doc) => (
+            <option key={doc.value} value={doc.value}>
+              {doc.label}
+            </option>
+          ))}
+        </select>
+        <a href={selectedUrl} target="_blank" rel="noopener noreferrer">
+          Open in new tab
+        </a>
+      </div>
+      <PdfViewer url={selectedUrl} />
+    </div>
+  );
 };

--- a/src/pages/pdfViewer.css.ts
+++ b/src/pages/pdfViewer.css.ts
@@ -24,3 +24,11 @@ export const canvas = style({
   height: "auto",
   display: "block",
 });
+
+// Iframe-based PDF viewer frame styling
+export const frame = style({
+  width: "100%",
+  height: "80vh",
+  border: "none",
+  display: "block",
+});

--- a/src/types/vanilla-extract.d.ts
+++ b/src/types/vanilla-extract.d.ts
@@ -1,0 +1,4 @@
+declare module "@vanilla-extract/css" {
+  export function style(styles: Record<string, unknown>): string;
+}
+


### PR DESCRIPTION
Add a dropdown PDF selector to the Rules page and embed searchable PDFs via iframes for improved document access and searchability.

The previous `PdfViewer` component used a canvas, which rendered PDFs as images, preventing text selection and search. Switching to an iframe allows the browser's native PDF viewer to handle rendering, enabling full text search and better accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a4f1c0e-cf05-42d6-a2e0-b06504721ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a4f1c0e-cf05-42d6-a2e0-b06504721ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

