### PR TITLE
Update rules page layout

### DIFF
--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -17,7 +17,7 @@ export const Rules: React.FC = () => {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        
+
         <select
           id="rules-doc-select"
           aria-label="Select rules document"
@@ -30,9 +30,6 @@ export const Rules: React.FC = () => {
             </option>
           ))}
         </select>
-        <a href={selectedUrl} target="_blank" rel="noopener noreferrer">
-          Open in new tab
-        </a>
       </div>
       <PdfViewer url={selectedUrl} />
     </div>


### PR DESCRIPTION
Remove the "Open in new tab" link from the rules page as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-14b8b263-b293-404f-ac9e-2814afe3de48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14b8b263-b293-404f-ac9e-2814afe3de48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

