### PR TITLE
Move pdf drop-down next to advanced search

### DIFF
--- a/src/mobile/SearchBar.tsx
+++ b/src/mobile/SearchBar.tsx
@@ -34,9 +34,20 @@ export const SearchBar: React.FC<Props> = ({
   onAdvancedSearch,
   onBuildDeck,
 }) => {
+  const rulesDocuments = useMemo(
+    () => [
+      { label: "Rules", value: "/assets/konivrer-rules.pdf" },
+      { label: "Tournament Rules", value: "/assets/konivrer-tournament-rules.pdf" },
+      { label: "Code of Conduct", value: "/assets/konivrer-code-of-conduct.pdf" },
+    ],
+    [],
+  );
   const [q, setQ] = useState("");
   const [contextOverride, setContextOverride] = useState<string | null>(null);
   const [showAdvancedSearch, setShowAdvancedSearch] = useState<boolean>(false);
+  const [selectedRulesDoc, setSelectedRulesDoc] = useState<string>(
+    "/assets/konivrer-rules.pdf",
+  );
   const [timeFrame, setTimeFrame] = useState<{ start: string; end: string }>({
     start: "",
     end: "",
@@ -137,6 +148,15 @@ export const SearchBar: React.FC<Props> = ({
     window.addEventListener("search-context", handler);
     return () => window.removeEventListener("search-context", handler);
   }, []);
+
+  // Keep Rules page PDF viewer in sync when user navigates to Rules
+  useEffect(() => {
+    if (current === "rules") {
+      window.dispatchEvent(
+        new CustomEvent("rules-doc-change", { detail: selectedRulesDoc }),
+      );
+    }
+  }, [current]);
 
   // Collapse advanced panel on pagination page changes from results views
   useEffect(() => {
@@ -825,6 +845,26 @@ export const SearchBar: React.FC<Props> = ({
             <option value="cosmology">Cosmology</option>
             <option value="pantheons_species">Pantheons & Species</option>
             <option value="societies_eras">Societies & Eras</option>
+          </select>
+        )}
+        {current === "rules" && (
+          <select
+            className={s.rulesDocSelect}
+            aria-label="Rules document"
+            value={selectedRulesDoc}
+            onChange={(e) => {
+              const url = e.target.value;
+              setSelectedRulesDoc(url);
+              window.dispatchEvent(
+                new CustomEvent("rules-doc-change", { detail: url }),
+              );
+            }}
+          >
+            {rulesDocuments.map((doc) => (
+              <option key={doc.value} value={doc.value}>
+                {doc.label}
+              </option>
+            ))}
           </select>
         )}
       </div>

--- a/src/mobile/searchBar.css.ts
+++ b/src/mobile/searchBar.css.ts
@@ -225,3 +225,14 @@ export const loreCategorySelect = style({
   minHeight: 36,
   cursor: "pointer",
 });
+
+export const rulesDocSelect = style({
+  background: "var(--secondary-bg, rgba(255,255,255,0.1))",
+  color: "var(--text-primary)",
+  border: "1px solid rgba(255,255,255,0.12)",
+  borderRadius: 8,
+  padding: "0.5rem 0.75rem",
+  fontSize: 14,
+  minHeight: 36,
+  cursor: "pointer",
+});

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { PdfViewer } from "./PdfViewer";
 
 export const Rules: React.FC = () => {
@@ -14,23 +14,18 @@ export const Rules: React.FC = () => {
 
   const [selectedUrl, setSelectedUrl] = useState<string>(documents[0].value);
 
+  // Listen for selection changes from the global SearchBar dropdown
+  useEffect(() => {
+    const onRulesDocChange = (e: Event) => {
+      const url = (e as CustomEvent<string>).detail;
+      if (typeof url === "string") setSelectedUrl(url);
+    };
+    window.addEventListener("rules-doc-change", onRulesDocChange);
+    return () => window.removeEventListener("rules-doc-change", onRulesDocChange);
+  }, []);
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-
-        <select
-          id="rules-doc-select"
-          aria-label="Select rules document"
-          value={selectedUrl}
-          onChange={(e) => setSelectedUrl(e.target.value)}
-        >
-          {documents.map((doc) => (
-            <option key={doc.value} value={doc.value}>
-              {doc.label}
-            </option>
-          ))}
-        </select>
-      </div>
       <PdfViewer url={selectedUrl} />
     </div>
   );


### PR DESCRIPTION
Move the PDF dropdown next to the advanced search on the Rules page to consolidate controls.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c763dff-1474-45aa-83ec-9fa1a4995893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c763dff-1474-45aa-83ec-9fa1a4995893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

